### PR TITLE
Fix compiler warnings

### DIFF
--- a/cl_multiview.c
+++ b/cl_multiview.c
@@ -339,7 +339,7 @@ void SCR_MV_DrawHealth (int x, int y, int *width, int *height, int style)
 	int health_amount_width = 0;
 
 	health = min (100, health);
-	health_amount_width = Q_rint (abs ((MV_HUD_HEALTH_WIDTH * health) / 100.0));
+	health_amount_width = Q_rint (fabs ((MV_HUD_HEALTH_WIDTH * health) / 100.0));
 
 	if (health > 0) {
 		Draw_AlphaFillRGB (x, y, health_amount_width, 8, ALPHA_COLOR (scr_autoid_healthbar_normal_color.color, 2 * MV_HEALTH_OPACITY));

--- a/cl_nqdemo.c
+++ b/cl_nqdemo.c
@@ -982,7 +982,7 @@ void NQD_LinkEntities (void)
 		// calculate origin
 		for (i = 0; i < 3; i++)
 		{
-			if (abs(cent->current.origin[i] - cent->old_origin[i]) > 128) {
+			if (fabs(cent->current.origin[i] - cent->old_origin[i]) > 128) {
 				// teleport or something, don't lerp
 				VectorCopy (cur_origin, ent.origin);
 				if (num == nq_viewentity)
@@ -1050,7 +1050,7 @@ void NQD_LinkEntities (void)
 				VectorCopy (cent->lerp_origin, old_origin);
 
 				for (i=0 ; i<3 ; i++)
-					if ( abs(old_origin[i] - ent.origin[i]) > 128)
+					if ( fabs(old_origin[i] - ent.origin[i]) > 128)
 					{	// no trail if too far
 						VectorCopy (ent.origin, old_origin);
 						break;

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -803,7 +803,7 @@ void SCR_DrawGameClock (void) {
 	if (cl.countdown || cl.standby)
 		strlcpy (str, SecondsToHourString(timelimit), sizeof(str));
 	else
-		strlcpy (str, SecondsToHourString((int) abs(timelimit - cl.gametime + scr_gameclock_offset.value)), sizeof(str));
+		strlcpy (str, SecondsToHourString((int) fabs(timelimit - cl.gametime + scr_gameclock_offset.value)), sizeof(str));
 
 	if ((scr_gameclock.value == 3 || scr_gameclock.value == 4) && (s = strstr(str, ":")))
 		s++;		// or just use SecondsToMinutesString() ...

--- a/cl_view.c
+++ b/cl_view.c
@@ -193,7 +193,7 @@ void V_DriftPitch (void) {
 
 // don't count small mouse motion
 	if (cl.nodrift) {
-		if ( fabs(cl.frames[(cls.netchan.outgoing_sequence-1)&UPDATE_MASK].cmd.forwardmove) < 200)
+		if ( abs(cl.frames[(cls.netchan.outgoing_sequence-1)&UPDATE_MASK].cmd.forwardmove) < 200)
 			cl.driftmove = 0;
 		else
 			cl.driftmove += cls.frametime;

--- a/common_draw.c
+++ b/common_draw.c
@@ -806,7 +806,7 @@ char* SCR_GetGameTime(int t)
 	if (cl.countdown || cl.standby)
 		strlcpy (str, SecondsToMinutesString(timelimit), sizeof(str));
 	else
-		strlcpy (str, SecondsToMinutesString((int) abs(timelimit - cl.gametime + *gameclockoffset)), sizeof(str));
+		strlcpy (str, SecondsToMinutesString((int) fabs(timelimit - cl.gametime + *gameclockoffset)), sizeof(str));
 
 	return str;
 }
@@ -1461,9 +1461,9 @@ void SCR_HUD_DrawBar(int direction, int value, float max_value, byte *color, int
 
 	if(direction >= 2)
 		// top-down
-		amount = Q_rint(abs((height * value) / max_value));
+		amount = Q_rint(fabs((height * value) / max_value));
 	else// left-right
-		amount = Q_rint(abs((width * value) / max_value));
+		amount = Q_rint(fabs((width * value) / max_value));
 
 	if(direction == 0)
 		// left->right

--- a/hud_common.c
+++ b/hud_common.c
@@ -5919,14 +5919,14 @@ void SCR_HUD_DrawKeys(hud_t *hud)
 	scale = max(0, scale);
 
 	i = 0;
-	line1[i++] = b.attack  ? 'x' + 128 : 'x';
-	line1[i++] = b.forward ? '^' + 128 : '^';
-	line1[i++] = b.jump    ? 'J' + 128 : 'J';
+	line1[i++] = b.attack  ? 'x' - 128 : 'x';
+	line1[i++] = b.forward ? '^' - 128 : '^';
+	line1[i++] = b.jump    ? 'J' - 128 : 'J';
 	line1[i++] = '\0';
 	i = 0;
-	line2[i++] = b.left    ? '<' + 128 : '<';
-	line2[i++] = b.back    ? '_' + 128 : '_';
-	line2[i++] = b.right   ? '>' + 128 : '>';
+	line2[i++] = b.left    ? '<' - 128 : '<';
+	line2[i++] = b.back    ? '_' - 128 : '_';
+	line2[i++] = b.right   ? '>' - 128 : '>';
 	line2[i++] = '\0';
 
 	width = LETTERWIDTH * strlen(line1) * scale;

--- a/hud_radar.c
+++ b/hud_radar.c
@@ -60,7 +60,7 @@ void HUD_NewRadarMap(void)
 		radar_pic_found = true;
 
 		// Calculate the height of the map.
-		map_height_diff = abs(cl.worldmodel->maxs[2] - cl.worldmodel->mins[2]);
+		map_height_diff = fabs(cl.worldmodel->maxs[2] - cl.worldmodel->mins[2]);
 
 		// Get the comments from the PNG.
 		txt = Image_LoadPNG_Comments(radar_filename, &n_textcount);

--- a/snd_voip.c
+++ b/snd_voip.c
@@ -382,7 +382,7 @@ void S_Voip_Transmit (unsigned char clc, sizebuf_t *buf)
 		for (i = 0; i < s_speex.framesize; i++) {
 			f = start[i] * micamp;
 			start[i] = f;
-			f = fabs (start[i]);
+			f = abs (start[i]);
 			level += f*f;
 		}
 		samps += s_speex.framesize;

--- a/sv_move.c
+++ b/sv_move.c
@@ -313,7 +313,7 @@ void SV_NewChaseDir (edict_t *actor, edict_t *enemy, float dist)
 	}
 
 	// try other directions
-	if ( ((rand()&3) & 1) ||  abs(deltay)>abs(deltax))
+	if ( ((rand()&3) & 1) ||  fabs(deltay)>fabs(deltax))
 	{
 		tdir=d[1];
 		d[1]=d[2];

--- a/vx_vertexlights.c
+++ b/vx_vertexlights.c
@@ -61,8 +61,8 @@ float VLight_GetLightValue(int index, float apitch, float ayaw)
 	while(yawofs < 0)
 		yawofs += 256;*/
 
-	pitchofs = fmodf(fabsf(pitchofs), 256);
-	yawofs = fmodf(fabsf(yawofs), 256);
+	pitchofs = fmodf(abs(pitchofs), 256);
+	yawofs = fmodf(abs(yawofs), 256);
 
 	retval = vlighttable[(unsigned int)pitchofs][(unsigned int)yawofs];
 


### PR DESCRIPTION
There are a number of compilation warnings when I compile ezquake on macOS High Sierra, this intends to fix the ones related to absolute values as noted in the compiler warnings. I also added some changes to fix some warnings about type conversions.