### PR TITLE
Support for the XDG base directory specification

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -705,7 +705,16 @@ void FS_InitFilesystemEx( qbool guess_cwd ) {
 		if(!(i = GetModuleFileName(NULL, com_basedir, sizeof(com_basedir)-1)))
 			Sys_Error("FS_InitFilesystemEx: GetModuleFileName failed");
 		com_basedir[i] = 0; // ensure null terminator
-#elif defined(__linux__)
+
+		// strip ezquake*.exe, we need only path
+		for (e = com_basedir+strlen(com_basedir)-1; e >= com_basedir; e--)
+			if (*e == '/' || *e == '\\')
+			{
+				*e = 0;
+				break;
+			}
+#else
+#if defined(__linux__)
 		if (!Sys_fullpath(com_basedir, "/proc/self/exe", sizeof(com_basedir)))
 			Sys_Error("FS_InitFilesystemEx: Sys_fullpath failed");
 #elif defined(__APPLE__)
@@ -716,17 +725,16 @@ void FS_InitFilesystemEx( qbool guess_cwd ) {
 		size_t com_basedirlen = sizeof(com_basedir);
 		if (sysctl(mib, 4, com_basedir, &com_basedirlen, NULL, 0) < 0)
 			Sys_Error("FS_InitFilesystemEx: sysctl failed");
-#else
-		com_basedir[0] = 0; // FIXME: others
 #endif
-
-		// strip ezquake*.exe, we need only path
+		// strip executable name, we need only path
 		for (e = com_basedir+strlen(com_basedir)-1; e >= com_basedir; e--)
-			if (*e == '/' || *e == '\\')
+			if (*e == '/')
 			{
 				*e = 0;
 				break;
 			}
+#endif //FIXME: others
+
 	}
 	else if ((i = COM_CheckParm (cmdline_param_filesystem_basedir)) && i < COM_Argc() - 1) {
 		// -basedir <path>

--- a/fs.c
+++ b/fs.c
@@ -572,7 +572,7 @@ void FS_AddUserDirectory(char *dir)
 	case 3: snprintf(com_userdir, sizeof(com_userdir), "%s/qw/%s", com_basedir, userdirfile); break;
 	case 4: snprintf(com_userdir, sizeof(com_userdir), "%s/%s", com_basedir, userdirfile); break;
 	case 5: {
-		const char* homedir;
+		char* homedir;
 #ifdef _WIN32
 		homedir = Sys_HomeDirectory();
 #else

--- a/fs.c
+++ b/fs.c
@@ -572,10 +572,16 @@ void FS_AddUserDirectory(char *dir)
 	case 3: snprintf(com_userdir, sizeof(com_userdir), "%s/qw/%s", com_basedir, userdirfile); break;
 	case 4: snprintf(com_userdir, sizeof(com_userdir), "%s/%s", com_basedir, userdirfile); break;
 	case 5: {
-		const char* homedir = Sys_HomeDirectory();
+		const char* homedir;
+#ifdef _WIN32
+		homedir = Sys_HomeDirectory();
+#else
+		homedir = strdup(getenv("HOME"));
+#endif
 		if (homedir && homedir[0]) {
 			snprintf(com_userdir, sizeof(com_userdir), "%s/qw/%s", homedir, userdirfile);
 		}
+		free(homedir);
 		break;
 	}
 	default:
@@ -695,6 +701,7 @@ void FS_ShutDown( void ) {
 void FS_InitFilesystemEx( qbool guess_cwd ) {
 	int i;
 	char tmp_path[MAX_OSPATH];
+	char *s;
 
 	FS_ShutDown();
 
@@ -758,7 +765,9 @@ void FS_InitFilesystemEx( qbool guess_cwd ) {
 	if (i >= 0 && com_basedir[i] == '/')
 		com_basedir[i] = 0;
 
-	strlcpy(com_homedir, Sys_HomeDirectory(), sizeof(com_homedir));
+	s = Sys_HomeDirectory();
+	strlcpy(com_homedir, s, sizeof(com_homedir));
+	free(s);
 
 	if (COM_CheckParm(cmdline_param_filesystem_nohome)) {
 		com_homedir[0] = 0;
@@ -769,7 +778,7 @@ void FS_InitFilesystemEx( qbool guess_cwd ) {
 #ifdef _WIN32
 		strlcat(com_homedir, "/ezQuake", sizeof(com_homedir));
 #else
-		strlcat(com_homedir, "/.ezquake", sizeof(com_homedir));
+		strlcat(com_homedir, "/ezquake", sizeof(com_homedir));
 #endif
 		Com_Printf("Using home directory \"%s\"\n", com_homedir);
 	}

--- a/menu_options.c
+++ b/menu_options.c
@@ -615,12 +615,9 @@ extern cvar_t cfg_backup, cfg_save_aliases, cfg_save_binds, cfg_save_cmdline,
 
 void MOpt_ImportConfig(void) {
 	MOpt_configpage_mode = MOCPM_CHOOSECONFIG;
+	char path[MAX_OSPATH];
 	
-	// hope few doubled trinary operator won't hurt your brains
-	if (cfg_use_home.integer)
-		FL_SetCurrentDir(&configs_filelist, (cfg_use_gamedir.integer) ? va("%s/%s", com_homedir, (strcmp(com_gamedirfile, "qw") == 0) ? "" : com_gamedirfile) : com_homedir);
-    else
-		FL_SetCurrentDir(&configs_filelist, (cfg_use_gamedir.integer) ? va("%s/%s/configs", com_basedir, (strcmp(com_gamedirfile, "qw") == 0) ? "ezquake" : com_gamedirfile) : va("%s/ezquake/configs", com_basedir));
+	FL_SetCurrentDir(&configs_filelist, Cfg_GetConfigPath(path, sizeof (path), ""));
 }
 void MOpt_ExportConfig(void) {
 	MOpt_configpage_mode = MOCPM_ENTERFILENAME;

--- a/sys.h
+++ b/sys.h
@@ -217,4 +217,5 @@ void *Sys_GetAddressForName(dllhandle_t *module, const char *exportname);
 void Sys_CvarInit(void);
 
 const char* Sys_FontsDirectory(void);
-const char* Sys_HomeDirectory(void);
+// Directoy for User's data files. returns string allocated with malloc. Must be freed.
+char* Sys_HomeDirectory(void);

--- a/sys_posix.c
+++ b/sys_posix.c
@@ -735,7 +735,7 @@ const char* Sys_FontsDirectory(void)
 	return sys_fontsdir.string;
 }
 
-const char* Sys_HomeDirectory(void)
+char* Sys_HomeDirectory(void)
 {
     char *ev, *buf;
     if (!(ev = getenv("XDG_DATA_HOME"))) {
@@ -749,7 +749,7 @@ const char* Sys_HomeDirectory(void)
     } else {
         buf = strdup(ev);
     }
-    return(buf)
+    return(buf);
 }
 
 #ifdef __MACOSX__
@@ -767,7 +767,7 @@ void Sys_RegisterQWURLProtocol_f(void)
     char open_cmd[MAX_PATH*2+1024] = { 0 };
     char exe_path[MAX_PATH] = { 0 };
     char buf[MAX_PATH] = { 0 };
-    const char *homedir = Sys_HomeDirectory();
+    char *homedir = Sys_HomeDirectory();
     int nchar = -1;
     FILE *fptr;
 
@@ -778,7 +778,7 @@ void Sys_RegisterQWURLProtocol_f(void)
         return;
     }
     snprintf(buf, sizeof(buf), "%s/applications", homedir);
-	free(homedir)
+	free(homedir);
     snprintf(open_cmd, sizeof(open_cmd), "mkdir -pm 0755 \"%s\"", buf);
     system(open_cmd);
 

--- a/sys_win.c
+++ b/sys_win.c
@@ -1656,12 +1656,14 @@ const char* Sys_FontsDirectory(void)
 
 const char* Sys_HomeDirectory(void)
 {
-	static char path[MAX_OSPATH];
+	char path[MAX_OSPATH], *res;
 
 	// gets "C:\documents and settings\johnny\my documents" path
 	if (!SHGetSpecialFolderPath(0, path, CSIDL_PERSONAL, 0)) {
 		path[0] = 0;
 	}
+	res = malloc(strlen(path) + 1);
+	strcpy(res, path);
 
 	// <Cokeman> yea, but it shouldn't be in My Documents
 	// <Cokeman> it should be in the application data dir
@@ -1670,5 +1672,5 @@ const char* Sys_HomeDirectory(void)
 	//	path[0] = 0;
 	//}
 
-	return path;
+	return res;
 }

--- a/sys_win.c
+++ b/sys_win.c
@@ -1654,7 +1654,7 @@ const char* Sys_FontsDirectory(void)
 	return path;
 }
 
-const char* Sys_HomeDirectory(void)
+char* Sys_HomeDirectory(void)
 {
 	char path[MAX_OSPATH], *res;
 


### PR DESCRIPTION
Uses `"$XDG_CONFIG_DIR"/ezquake` instead of `"$HOME"/.ezquake` if `$XDG_CONFIG_DIR` is set.