### PR TITLE
Vsync fix for MacOS

### DIFF
--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -1219,10 +1219,11 @@ void GL_BeginRendering (int *x, int *y, int *width, int *height)
 {
     // MacOS vsync fix
     #ifdef __APPLE__
-    GLint                       sync = 0;
-    CGLContextObj               ctx = CGLGetCurrentContext();
-
-    CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
+    if (r_swapInterval.integer == 0) {
+        GLint                       sync = 0;
+        CGLContextObj               ctx = CGLGetCurrentContext();
+        CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
+    }
     #endif
 
 	*x = *y = 0;

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -38,6 +38,7 @@ void Sys_ActiveAppChanged (void);
 
 #ifdef __APPLE__
 #include <OpenGL/gl.h>
+#include <OpenGL/OpenGL.h>
 #include "in_osx.h"
 #else
 #include <GL/gl.h>
@@ -1216,6 +1217,14 @@ static void GL_SwapBuffersWithVsyncFix(void)
 
 void GL_BeginRendering (int *x, int *y, int *width, int *height)
 {
+    // MacOS vsync fix
+    #ifdef __APPLE__
+    GLint                       sync = 0;
+    CGLContextObj               ctx = CGLGetCurrentContext();
+
+    CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
+    #endif
+
 	*x = *y = 0;
 	*width  = glConfig.vidWidth;
 	*height = glConfig.vidHeight;

--- a/vid_sdl2.c
+++ b/vid_sdl2.c
@@ -1217,14 +1217,6 @@ static void GL_SwapBuffersWithVsyncFix(void)
 
 void GL_BeginRendering (int *x, int *y, int *width, int *height)
 {
-    // MacOS vsync fix
-    #ifdef __APPLE__
-    if (r_swapInterval.integer == 0) {
-        GLint                       sync = 0;
-        CGLContextObj               ctx = CGLGetCurrentContext();
-        CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
-    }
-    #endif
 
 	*x = *y = 0;
 	*width  = glConfig.vidWidth;
@@ -1242,6 +1234,12 @@ void GL_EndRendering (void)
 			if (SDL_GL_SetSwapInterval(0)) {
 				Con_Printf("vsync: Failed to disable vsync...\n");
 			}
+            // MacOS vsync fix
+            #ifdef __APPLE__
+            GLint                       sync = 0;
+            CGLContextObj               ctx = CGLGetCurrentContext();
+            CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
+            #endif
 		} else if (r_swapInterval.integer == -1) {
 			if (SDL_GL_SetSwapInterval(-1)) {
 				Con_Printf("vsync: Failed to enable late swap tearing (vid_vsync -1), setting vid_vsync 1 instead...\n");


### PR DESCRIPTION
This is the only way to work around this hardcoded limitation on MacOS.
Other cvars have no effect and MacOS offers no GL driver options.