### PR TITLE
IGNORE: Automatically ignore unezQuake inlay messages

### DIFF
--- a/cl_parse.c
+++ b/cl_parse.c
@@ -2880,6 +2880,11 @@ void CL_ProcessPrint (int level, char* s0)
 			return;
 		}
 
+		if (flags == 2 && strstr(s0, "#inlay#") ) {
+			Com_DPrintf("Ignoring unezQuake inlay message: %s\n", s0);
+			return;
+		}
+
 		if (flags == 2 && !TP_FilterMessage (s + offset)) {
 			Com_DPrintf("Filtered message: %s\n", s0);
 			return;


### PR DESCRIPTION
unezQuake sends `say_team` messages with "#inlay#" which is incompatible with the limited `filter` system of ezQuake. Ignore these messages like we ignore Qizmo messages.