### PR TITLE
FEAT: Add easymove from jquake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,7 @@ OBJS_c := \
     cl_cmd.o \
     cl_demo.o \
     cl_nqdemo.o \
+    cl_easymove.o \
     cl_ents.o \
     cl_input.o \
     cl_main.o \

--- a/cl_easymove.c
+++ b/cl_easymove.c
@@ -1,0 +1,289 @@
+/*
+Copyright (C) 2013 Anton (tonik) Gavrilov.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "quakedef.h"
+#include "pmove.h"
+
+cvar_t cl_easymove = {"cl_easymove", "0"};
+cvar_t cl_autohop = {"cl_autohop", "0"};
+qbool em_touch_wall;
+qbool em_jump_held;
+
+static float pm_frametime;
+
+static float AngleMod (float a)
+{
+	if (a > 180)
+		a -= 360;
+	if (a <= - 180)
+		a += 360;
+	return a;
+}
+
+
+static float FindMax (float start, float end, float (*f)(float))
+{
+	float p1, p2;
+
+	while (end - start > 0.01)
+	{
+		p1 = start + (end - start) / 3.0;
+		p2 = start + (end - start) * 2.0 / 3.0;
+
+		if (f(p1) > f(p2))
+			end = p2;
+		else
+			start = p1;
+	};
+
+	return (end + start)/2;
+};
+
+
+static void Friction (vec3_t velocity)
+{
+	float speed, newspeed, control;
+	float friction;
+	float drop;
+	
+	speed = VectorLength(velocity);
+	if (speed < 1)
+	{
+		velocity[0] = 0;
+		velocity[1] = 0;
+		return;
+	}
+
+	/* apply ground friction */
+	friction = movevars.friction;
+
+	control = speed < movevars.stopspeed ? movevars.stopspeed : speed;
+	drop = control*friction*pm_frametime;
+
+	/* scale the velocity */
+	newspeed = speed - drop;
+	if (newspeed < 0)
+		newspeed = 0;
+
+	VectorScale (velocity, newspeed / speed, velocity);
+}
+
+static void Accelerate (vec3_t wishdir, float wishspd, vec3_t velocity)
+{
+	int   i;
+	float addspeed, accelspeed, currentspeed;
+	float wishspd_orig = wishspd;
+
+	currentspeed = DotProduct (velocity, wishdir); 
+	addspeed = wishspd - currentspeed;
+	if (addspeed <= 0)
+		return;
+
+	accelspeed = movevars.accelerate * wishspd_orig * pm_frametime;
+	if (accelspeed > addspeed)
+		accelspeed = addspeed;
+
+	for (i=0 ; i<3 ; i++)
+		velocity[i] += accelspeed*wishdir[i];
+}
+
+static vec3_t ra_curvel, ra_intentions;
+static float RankAngle (float a)
+{
+	vec3_t wishdir;
+	float  delta;
+	vec3_t ang1, ang2;
+	vec3_t newvel;
+
+	wishdir[0] = cos(a / 180 * M_PI);
+	wishdir[1] = sin(a / 180 * M_PI);
+	wishdir[2] = 0;
+
+	VectorCopy (ra_curvel, newvel);
+	Friction (newvel);
+	Accelerate (wishdir, movevars.maxspeed, newvel);
+
+	vectoangles (newvel, ang1);
+	vectoangles (ra_intentions, ang2);
+
+	delta = AngleMod(ang2[YAW] - ang1[YAW]);
+
+	return -fabs(delta);
+}
+
+static float BestAngle (vec3_t curvel, vec3_t intentions, qbool onground)
+{
+	float  a1, a2;
+	vec3_t cross;
+	vec3_t tmp;
+	float  ba;
+	float  max;
+
+	a1 = 0;
+	a2 = 95;
+	CrossProduct (curvel, intentions, cross);
+	if (cross[2] < 0)
+	{
+		a1 = -a1;
+		a2 = -a2;
+	}
+
+	VectorCopy(curvel, ra_curvel);
+	VectorCopy(intentions, ra_intentions);
+
+	vectoangles (curvel, tmp);
+	ba = tmp[YAW];
+
+	if (a2 > a1)
+		max = FindMax (ba + a1, ba + a2, RankAngle);
+	else
+		max = FindMax (ba + a2, ba + a1, RankAngle);
+
+	return max;
+}
+
+static float ZeroAngle (float speed)
+{
+	if (!speed)
+		return 0;
+
+	return acos(30/speed)/M_PI*180;
+}
+
+static void TweakMovement (usercmd_t *cmd)
+{
+	vec3_t fw, rt;
+	vec3_t movevec;
+	vec3_t v1, ang;
+	float a;
+	float delta;
+	vec3_t intentions;
+	vec3_t intentions_a;
+	vec3_t cmd_ang;
+	qbool onground;
+	static qbool locked = false;
+	static double startlock = -1;
+	static float olddelta;
+	static qbool olddelta_valid = false;
+	static short oldmove[2];
+
+	if (!cl_easymove.value || cl.waterlevel)
+		return;
+
+	if (!cmd->forwardmove && !cmd->sidemove)
+	{
+		oldmove[0] = oldmove[1] = 0;
+		return;
+	}
+
+	onground = (cl.onground && !((cmd->buttons & BUTTON_JUMP) && !em_jump_held));
+
+	VectorCopy (cmd->angles, cmd_ang);
+	cmd_ang[PITCH] = 0;
+	cmd_ang[ROLL] = 0;
+	AngleVectors (cmd_ang, fw, rt, NULL);
+	VectorScale (fw, cmd->forwardmove, intentions);
+	VectorMA (intentions, cmd->sidemove, rt, intentions);
+	vectoangles (intentions, intentions_a);
+
+	VectorCopy (cl.simvel, v1);
+
+	v1[2] = 0;
+
+	if (VectorLength(v1) < 30)
+		return;
+
+	vectoangles (v1, ang);
+	delta = AngleMod(intentions_a[YAW] - ang[YAW]);
+
+	if (!locked && startlock == -1)
+		startlock = curtime;
+
+	if ((cmd->forwardmove != oldmove[0] || cmd->sidemove != oldmove[1])
+	&& (!onground || (oldmove[0] || oldmove[1]))) {
+		locked = false;
+		olddelta_valid = false;
+		startlock = curtime;
+	}
+	oldmove[0] = cmd->forwardmove;
+	oldmove[1] = cmd->sidemove;
+
+	if (fabs(delta) < 0.5 || (olddelta_valid && (
+		(olddelta >= 0 && delta <= 0) || (olddelta <= 0 && delta >= 0)
+		|| fabs(delta) > fabs(olddelta) + 0.1)) ) {
+			locked = true;
+	}
+	olddelta = delta;
+	olddelta_valid = true;
+
+	if (curtime - startlock > (onground ? 0.1 : 0.3))
+		locked = true;
+
+	if (fabs(delta) > 95) {
+		locked = true;
+		return;
+	}
+
+	if (!locked || em_touch_wall)
+		return;
+
+	if (onground)
+	{
+		if (fabs(delta) < 0.5)
+			return;
+		a = BestAngle (v1, intentions, onground);
+	}
+	else
+	{
+		a = intentions_a[YAW] + (delta > 0 ? 1 : -1)*ZeroAngle(VectorLength(v1));
+	}
+
+	VectorClear (ang);
+	ang[YAW] = a;
+	AngleVectors (ang, movevec, NULL, NULL);
+	cmd->forwardmove = DotProduct (movevec, fw) * 500;
+	cmd->sidemove = DotProduct (movevec, rt) * 500;
+}
+
+static void Autohop (usercmd_t *cmd)
+{
+	static float oldzvel;
+
+	if (!(cmd->buttons & 2))
+	{
+		oldzvel = cl.simvel[2];
+		return;
+	}
+	if (!cl_autohop.value)
+		return;
+	if (cl.simvel[2] <= 0 && oldzvel > 0)
+		cmd->buttons &= ~2;
+	oldzvel = cl.simvel[2];
+}
+
+void CL_EasyMove (usercmd_t *cmd)
+{
+	if (cl.spectator || cl.intermission || cl.stats[STAT_HEALTH] < 0)
+		return;
+
+	pm_frametime = cmd->msec * 0.001;
+	TweakMovement (cmd);
+	Autohop (cmd);
+}

--- a/cl_input.c
+++ b/cl_input.c
@@ -897,6 +897,7 @@ int MakeChar(int i)
 	return i;
 }
 
+extern void CL_EasyMove(usercmd_t *cmd);
 void CL_FinishMove(usercmd_t *cmd)
 {
 	int i, ms;
@@ -939,6 +940,8 @@ void CL_FinishMove(usercmd_t *cmd)
 	cmd->msec = ms;
 
 	VectorCopy (cl.viewangles, cmd->angles);
+
+	CL_EasyMove(cmd);
 
 	if (!cl.spectator && CL_INPUT_WEAPONHIDE_DUE_TO_DEATH(cl.stats[STAT_HEALTH])) {
 		cl.weapon_order[0] = in_next_impulse = (cl_weaponhide_axe.integer ? 1 : 2);
@@ -1382,7 +1385,7 @@ void CL_InitInput(void)
 	Cvar_Register(&lookstrafe);
 	Cvar_Register(&sensitivity);
 	Cvar_Register(&freelook);
-	
+
 	Cvar_SetCurrentGroup(CVAR_GROUP_MENU);
 	Cvar_Register(&cursor_sensitivity);
 
@@ -1431,4 +1434,3 @@ void onchange_pext_serversideweapon(cvar_t* var, char* value, qbool* cancel)
 {
 	cl.weapon_order_sequence_set = cls.netchan.outgoing_sequence;
 }
-

--- a/cl_pred.c
+++ b/cl_pred.c
@@ -8,7 +8,7 @@ of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 See the GNU General Public License for more details.
 
@@ -163,7 +163,7 @@ void CL_DisableLerpMove(void)
 }
 
 static void CL_LerpMove (qbool angles_lerp)
-{	
+{
 	static int		lastsequence = 0;
 	static vec3_t	lerp_angles[3];
 	static vec3_t	lerp_origin[3];
@@ -181,13 +181,13 @@ static void CL_LerpMove (qbool angles_lerp)
 	double  current_lerp_time = cls.demoplayback ? cls.demopackettime : (cmdtime_msec * 0.001);
 	qbool   physframe = cls.netchan.outgoing_sequence != lastsequence;
 
-	if ((cl_nolerp.value || cl_nolerp_on_entity_flag)) 
+	if ((cl_nolerp.value || cl_nolerp_on_entity_flag))
 	{
 		lastsequence = ((unsigned)-1) >> 1;	//reset
 		return;
 	}
 
-	if (cls.netchan.outgoing_sequence < lastsequence) 
+	if (cls.netchan.outgoing_sequence < lastsequence)
 	{
 		// reset
 		lastsequence = -1;
@@ -241,16 +241,16 @@ static void CL_LerpMove (qbool angles_lerp)
 	simtime = current_time - demo_latency;
 
 	// Adjust latency
-	if (simtime > lerp_times[0]) 
+	if (simtime > lerp_times[0])
 	{
 		// High clamp
 		demo_latency = current_time - lerp_times[0];
 	}
-	else if (simtime < lerp_times[2]) 
+	else if (simtime < lerp_times[2])
 	{
 		// Low clamp
 		demo_latency = current_time - lerp_times[2];
-	} 
+	}
 	else
 	{
 		// slowly drift down till corrected
@@ -262,7 +262,7 @@ static void CL_LerpMove (qbool angles_lerp)
 	if (simtime > lerp_times[1]) {
 		from = 1;
 		to = 0;
-	} 
+	}
 	else {
 		from = 2;
 		to = 1;
@@ -294,13 +294,15 @@ static void check_standing_on_entity(void)
   extern cvar_t cl_nolerp;
   extern cvar_t cl_nolerp_on_entity;
   extern cvar_t cl_independentPhysics;
-  cl_nolerp_on_entity_flag = 
+  cl_nolerp_on_entity_flag =
        (pmove.onground && pmove.groundent > 0 &&
         cl_nolerp_on_entity.value &&
         cl_independentPhysics.value);
 }
 
 void CL_PredictMove (qbool physframe) {
+	extern qbool em_touch_wall, em_jump_held;
+
 	int i, oldphysent;
 	frame_t *from = NULL, *to;
 	qbool angles_lerp = false;
@@ -378,6 +380,9 @@ void CL_PredictMove (qbool physframe) {
 		VectorCopy (to->playerstate[cl.playernum].origin, cl.simorg);
 		cl.onground = pmove.onground;
 		cl.waterlevel = pmove.waterlevel;
+		em_touch_wall = pmove.touch_wall;
+		em_jump_held = pmove.jump_held;
+
 		check_standing_on_entity();
 	}
 
@@ -412,17 +417,18 @@ void CL_PredictMove (qbool physframe) {
 		VectorMA (pstate->origin, -cam_dist.value, fw, cl.simorg);
 	}
 #endif	// JSS_CAM
-	
+
 }
 
 void CL_InitPrediction (void) {
+	extern cvar_t cl_easymove, cl_autohop;
 	Cvar_SetCurrentGroup(CVAR_GROUP_NETWORK);
 	Cvar_Register(&cl_nopred);
 	Cvar_Register(&cl_pushlatency);
 
 	Cvar_ResetCurrentGroup();
 
-#ifdef JSS_CAM	
+#ifdef JSS_CAM
 	Cvar_SetCurrentGroup(CVAR_GROUP_SPECTATOR);
 	Cvar_Register(&cam_thirdperson);
 	Cvar_Register(&cam_dist);
@@ -430,5 +436,6 @@ void CL_InitPrediction (void) {
 	Cvar_Register(&cam_lockpos);
 	Cvar_ResetCurrentGroup();
 #endif
+	Cvar_Register(&cl_easymove);
+	Cvar_Register(&cl_autohop);
 }
- 

--- a/ezQuake.vcxproj
+++ b/ezQuake.vcxproj
@@ -1052,6 +1052,7 @@ msversion.bat</Command>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='rls-all|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='dbg-vulkan|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="cl_easymove.c" />
     <ClCompile Include="cl_ents.c" />
     <ClCompile Include="cl_input.c" />
     <ClCompile Include="cl_main.c">

--- a/ezQuake.vcxproj.filters
+++ b/ezQuake.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="cl_demo.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="cl_easymove.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="cl_ents.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/pmove.c
+++ b/pmove.c
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-	
+
 */
 
 #ifdef SERVERONLY
@@ -124,11 +124,19 @@ static int PM_SlideMove (void)
 		PM_AddTouchedEnt (trace.e.entnum);
 
 		if (trace.plane.normal[2] >= MIN_STEP_NORMAL)
+		{
 			blocked |= BLOCKED_FLOOR;
+		}
 		else if (!trace.plane.normal[2])
+		{
 			blocked |= BLOCKED_STEP;
+			pmove.touch_wall = true;
+		}
 		else
+		{
 			blocked |= BLOCKED_OTHER;
+			pmove.touch_wall = true;
+		}
 
 		time_left -= time_left * trace.fraction;
 
@@ -219,6 +227,9 @@ static int PM_StepSlideMove (qbool in_air)
 		dest[2] -= STEPSIZE;
 		trace = PM_PlayerTrace (org, dest);
 		if (trace.fraction == 1 || trace.plane.normal[2] < MIN_STEP_NORMAL) {
+			if (trace.fraction != 1)
+				pmove.touch_wall = true;
+
 			return blocked;
 		}
 
@@ -895,6 +906,7 @@ int PM_PlayerMove(void)
 
 	pm_frametime = pmove.cmd.msec * 0.001;
 	pmove.numtouch = 0;
+	pmove.touch_wall = false;
 
 	if (pmove.pm_type == PM_NONE || pmove.pm_type == PM_LOCK) {
 		PM_CategorizePosition();

--- a/pmove.h
+++ b/pmove.h
@@ -8,7 +8,7 @@ of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 See the GNU General Public License for more details.
 
@@ -16,13 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-	
+
 */
 
 #ifndef __PMOVE_H__
 #define __PMOVE_H__
 
-#define	MAX_PHYSENTS 64 
+#define	MAX_PHYSENTS 64
 
 typedef struct {
 	vec3_t		origin;
@@ -59,6 +59,7 @@ typedef struct {
 	usercmd_t	cmd;
 
 	// results
+	qbool		touch_wall;
 	int			numtouch;
 	int			touchindex[MAX_PHYSENTS];
 	qbool		onground;

--- a/rulesets.c
+++ b/rulesets.c
@@ -210,14 +210,18 @@ static void Rulesets_Smackdown(qbool enable)
 	extern cvar_t r_shiftbeam;
 	extern cvar_t allow_scripts;
 	extern cvar_t cl_iDrive;
+	extern cvar_t cl_autohop;
+	extern cvar_t cl_easymove;
 	int i;
 
 	locked_cvar_t disabled_cvars[] = {
-		{&allow_scripts, "0"},  // disable movement scripting
-		{&cl_iDrive, "0"},      // disable strafing aid
-		{&cl_hud, "0"},         // allows you place any text on the screen & filter incoming messages (hud strings)
-		{&cl_rollalpha, "20"},  // allows you to not dodge while seeing enemies dodging
-		{&r_shiftbeam, "0"}     // perphaps some people would think this allows you to aim better (maybe should be added for demo playback and spectating only)
+		{&allow_scripts, "0"},      // disable movement scripting
+		{&cl_iDrive, "0"},          // disable strafing aid
+		{&cl_hud, "0"},             // allows you place any text on the screen & filter incoming messages (hud strings)
+		{&cl_rollalpha, "20"},      // allows you to not dodge while seeing enemies dodging
+		{&r_shiftbeam, "0"},        // perphaps some people would think this allows you to aim better (maybe should be added for demo playback and spectating only)
+		{&cl_autohop, "0"},         // disable automatic release+press of jump (speedjump help aid), this is meant as a help aid for people with disabilities
+		{&cl_easymove, "0"}         // disable holding +forward and turn with mouse, this is meant as a help aid for people with disabilities
 	};
 
 	if (enable) {


### PR DESCRIPTION
Easymove is a mode where you can strafejump simply by holding shift and +forward.

It is usable by people who can't bunny jump properly because of
e.g. a disability or similar, and helps them to be competitive
in games with friends.

It is disabled by default in ruleset smackdown.

The feature was written by Tonik.