### PR TITLE
Updates to scoreboard, shownick and teaminfo

### DIFF
--- a/cl_parse.c
+++ b/cl_parse.c
@@ -3157,6 +3157,12 @@ void CL_ParseStufftext (void)
 		if (!cls.mvdplayback)
 			Parse_TeamInfo( s + 2 );
 	}
+	else if (!strncmp(s, "//cainfo ", sizeof("//cainfo ") - 1))
+	{
+		extern void Parse_CAInfo(char *s);
+
+		Parse_CAInfo( s + 2 );
+	}
 	else if (!strncmp(s, "//at ", sizeof("//at ") - 1))
 	{
 		// This is autotrack info from MVD demo/QTV stream, they are almost same.

--- a/cl_parse.c
+++ b/cl_parse.c
@@ -3076,6 +3076,10 @@ void CL_ParsePrint (void)
 void CL_ParseStufftext (void) 
 {
 	char *s = MSG_ReadString();
+	char *ktxmode = Info_ValueForKey(cl.serverinfo, "mode");
+	qbool ktx_ca = (strstr(ktxmode, "-ca") != NULL);
+	qbool ktx_wipeout = (strstr(ktxmode, "-wo") != NULL);
+	qbool ktx_ca_wipeout = (ktx_ca || ktx_wipeout);
 
 	// Always process demomarks, regardless of who inserted them
 	if (!strcmp(s, "//demomark\n"))
@@ -3154,8 +3158,10 @@ void CL_ParseStufftext (void)
 	{
 		extern void Parse_TeamInfo(char *s);
 
-		if (!cls.mvdplayback)
+		if (!cls.mvdplayback && !ktx_ca_wipeout)
+		{
 			Parse_TeamInfo( s + 2 );
+		}
 	}
 	else if (!strncmp(s, "//cainfo ", sizeof("//cainfo ") - 1))
 	{

--- a/cl_parse.c
+++ b/cl_parse.c
@@ -3076,10 +3076,6 @@ void CL_ParsePrint (void)
 void CL_ParseStufftext (void) 
 {
 	char *s = MSG_ReadString();
-	char *ktxmode = Info_ValueForKey(cl.serverinfo, "mode");
-	qbool ktx_ca = (strstr(ktxmode, "-ca") != NULL);
-	qbool ktx_wipeout = (strstr(ktxmode, "-wo") != NULL);
-	qbool ktx_ca_wipeout = (ktx_ca || ktx_wipeout);
 
 	// Always process demomarks, regardless of who inserted them
 	if (!strcmp(s, "//demomark\n"))
@@ -3158,7 +3154,7 @@ void CL_ParseStufftext (void)
 	{
 		extern void Parse_TeamInfo(char *s);
 
-		if (!cls.mvdplayback && !ktx_ca_wipeout)
+		if (!cls.mvdplayback && !check_ktx_ca_wo())
 		{
 			Parse_TeamInfo( s + 2 );
 		}

--- a/help_variables.json
+++ b/help_variables.json
@@ -12770,6 +12770,22 @@
         }
       ]
     },
+    "hud_teaminfo_show_ammo": {
+      "desc": "Display ammo count next to best weapon in the teaminfo.",
+      "group-id": "19",
+      "remarks": "If disabled, ammo can still be displayed by adding %c to /hud_teaminfo_layout",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Do not show ammo next to best weapon",
+          "name": "0"
+        },
+        {
+          "description": "Show ammo next to best weapon",
+          "name": "1"
+        }
+      ]
+    },
     "hud_teaminfo_show_enemies": {
       "desc": "Show information about the enemy team(s) in the teaminfo window. Displays a header for each team consisting of the team name and the current team score.",
       "group-id": "19",
@@ -18808,6 +18824,12 @@
       "group-id": "40",
       "type": "float"
     },
+    "scr_shownick_show_ammo": {
+      "default": "0",
+      "desc": "Displays ammo count next to best weapon.",
+      "group-id": "40",
+      "type": "boolean"
+    },
     "scr_shownick_time": {
       "default": "0.8",
       "desc": "Number of seconds to show results of '/shownick 1' command in KTX.",
@@ -19009,6 +19031,23 @@
         {
           "description": "From 0 (very small) to 10 (very big)",
           "name": "*"
+        }
+      ]
+    },
+    "scr_teaminfo_show_ammo": {
+      "default": "0",
+      "desc": "Will show ammo count next to best weapon in teaminfo table.",
+      "group-id": "40",
+      "remarks": "If disabled, ammo can still be displayed by adding %c to /scr_teaminfo_order",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Do not show ammo next to best weapon.",
+          "name": "0"
+        },
+        {
+          "description": "Show ammo next to best weapon.",
+          "name": "1"
         }
       ]
     },

--- a/help_variables.json
+++ b/help_variables.json
@@ -12786,6 +12786,22 @@
         }
       ]
     },
+    "hud_teaminfo_show_countdown": {
+      "desc": "Shows respawn time instead of powerups during wipeout mode.",
+      "group-id": "19",
+      "remarks": "If disabled, countdown can still be displayed by adding %r to /hud_teaminfo_layout",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Do not show respawn time instead of powerups in wipeout mode",
+          "name": "0"
+        },
+        {
+          "description": "Show respawn time instead of powerups in wipeout mode",
+          "name": "1"
+        }
+      ]
+    },
     "hud_teaminfo_show_enemies": {
       "desc": "Show information about the enemy team(s) in the teaminfo window. Displays a header for each team consisting of the team name and the current team score.",
       "group-id": "19",
@@ -19047,6 +19063,23 @@
         },
         {
           "description": "Show ammo next to best weapon.",
+          "name": "1"
+        }
+      ]
+    },
+    "scr_teaminfo_show_countdown": {
+      "default": "0",
+      "desc": "Shows respawn time instead of powerups during wipeout mode.",
+      "group-id": "40",
+      "remarks": "If disabled, countdown can still be displayed by adding %r to /scr_teaminfo_order",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Do not show respawn time instead of powerups in wipeout mode",
+          "name": "0"
+        },
+        {
+          "description": "Show respawn time instead of powerups in wipeout mode",
           "name": "1"
         }
       ]

--- a/help_variables.json
+++ b/help_variables.json
@@ -18794,6 +18794,21 @@
         }
       ]
     },
+    "scr_scoreboard_wipeout": {
+      "default": "1",
+      "group-id": "47",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Display normal scoreboard during clan arena or wipeout modes.",
+          "name": "false"
+        },
+        {
+          "description": "Display game-specific scoreboard during clan arena or wipeout modes.",
+          "name": "true"
+        }
+      ]
+    },
     "scr_showcrosshair": {
       "default": "1",
       "desc": "Allows you to force the display of the crosshair when in menus or in scoreboard.",

--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -812,6 +812,8 @@ void Parse_CAInfo(char *s)
 	ti_clients[client].camode = atoi(Cmd_Argv(13));
 	ti_clients[client].isdead = atoi(Cmd_Argv(14));
 	ti_clients[client].timetospawn = atoi(Cmd_Argv(15));
+	ti_clients[client].round_kills = atoi(Cmd_Argv(16));
+	ti_clients[client].round_deaths = atoi(Cmd_Argv(17));
 }
 
 void Update_FlagStatus(int player_num, char *team, qbool got_flag)

--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -250,13 +250,9 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 {
 	extern cvar_t tp_name_rlg;
 	char *s, *loc, tmp[1024], tmp2[MAX_MACRO_STRING], *aclr, *txtclr;
-	char * ktxmode = Info_ValueForKey(cl.serverinfo, "mode"); // check KTX game mode
 	float x_in = x; // save x
 	int i, a;
 	qbool isDeadCA, isRespawning;
-	qbool ktx_ca = (strstr(ktxmode, "-ca") != NULL);
-	qbool ktx_wipeout = (strstr(ktxmode, "-wo") != NULL);
-	qbool ktx_ca_wipeout = (ktx_ca || ktx_wipeout);
 	mpic_t *pic;
 	float width;
 	float font_width = scale * FONT_WIDTH;
@@ -510,7 +506,7 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 						break;
 
 					case 'p': // draw powerups
-						if (show_countdown && ktx_ca_wipeout)
+						if (show_countdown && check_ktx_ca_wo())
 						{
 							if (!width_only) {
 								if (isRespawning)

--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -41,6 +41,7 @@ static cvar_t scr_shownick_x               = { "scr_shownick_x",			"0" };
 static cvar_t scr_shownick_name_width      = { "scr_shownick_name_width",	"6" };
 static cvar_t scr_shownick_time            = { "scr_shownick_time",		"0.8" };
 static cvar_t scr_shownick_proportional    = { "scr_shownick_proportional", "0" };
+static cvar_t scr_shownick_show_ammo	   = { "scr_shownick_show_ammo", "0" };
 
 static cvar_t scr_teaminfo_order           = { "scr_teaminfo_order", "%p%n $x10%l$x11 %a/%H %w", CVAR_NONE };
 static cvar_t scr_teaminfo_align_right     = { "scr_teaminfo_align_right", "1" };
@@ -55,12 +56,13 @@ static cvar_t scr_teaminfo_armor_style     = { "scr_teaminfo_armor_style", "3" }
 static cvar_t scr_teaminfo_powerup_style   = { "scr_teaminfo_powerup_style", "1" };
 static cvar_t scr_teaminfo_flag_style      = { "scr_teaminfo_flag_style",  "1" };
 static cvar_t scr_teaminfo_weapon_style    = { "scr_teaminfo_weapon_style","1" };
+static cvar_t scr_teaminfo_show_ammo	   = { "scr_teaminfo_show_ammo","0" };
 static cvar_t scr_teaminfo_show_enemies    = { "scr_teaminfo_show_enemies","0" };
 static cvar_t scr_teaminfo_show_self       = { "scr_teaminfo_show_self",   "2" };
 static cvar_t scr_teaminfo_proportional    = { "scr_teaminfo_proportional", "0"};
 cvar_t scr_teaminfo                        = { "scr_teaminfo",             "1" };   // non-static for menu
 
-static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional);
+static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int show_ammo, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional);
 
 static int HUD_CompareTeamInfoSlots(const void* lhs_, const void* rhs_)
 {
@@ -99,6 +101,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 		*hud_teaminfo_align_right,
 		*hud_teaminfo_loc_width,
 		*hud_teaminfo_name_width,
+		*hud_teaminfo_show_ammo,
 		*hud_teaminfo_show_enemies,
 		*hud_teaminfo_show_self,
 		*hud_teaminfo_show_headers,
@@ -117,6 +120,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 		hud_teaminfo_align_right = HUD_FindVar(hud, "align_right");
 		hud_teaminfo_loc_width = HUD_FindVar(hud, "loc_width");
 		hud_teaminfo_name_width = HUD_FindVar(hud, "name_width");
+		hud_teaminfo_show_ammo = HUD_FindVar(hud, "show_ammo");
 		hud_teaminfo_show_enemies = HUD_FindVar(hud, "show_enemies");
 		hud_teaminfo_show_self = HUD_FindVar(hud, "show_self");
 		hud_teaminfo_show_headers = HUD_FindVar(hud, "show_headers");
@@ -175,7 +179,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 	header_spacing = max(0, hud_teaminfo_header_spacing->value);
 
 	// this doesn't draw anything, just calculate width
-	width = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
+	width = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
 	height = FONTWIDTH * hud_teaminfo_scale->value * (hud_teaminfo_show_enemies->integer && hud_teaminfo_show_headers->integer ? slots_num + max(2 * n_teams - 1, 0) * header_spacing : slots_num);
 
 	if (hud_editor) {
@@ -218,7 +222,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 			for (j = 0; j < slots_num; j++) {
 				i = slots[j];
 				if (!strcmp(cl.players[i].team, sorted_teams[k].name)) {
-					SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
+					SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
 					_y += FONTWIDTH * hud_teaminfo_scale->value;
 				}
 			}
@@ -228,7 +232,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 	else {
 		for (j = 0; j < slots_num; j++) {
 			i = slots[j];
-			SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
+			SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
 			_y += FONTWIDTH * hud_teaminfo_scale->value;
 		}
 	}
@@ -239,7 +243,7 @@ qbool Has_Both_RL_and_LG(int flags)
 	return (flags & IT_ROCKET_LAUNCHER) && (flags & IT_LIGHTNING);
 }
 
-static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional)
+static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int show_ammo, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional)
 {
 	extern cvar_t tp_name_rlg;
 
@@ -268,6 +272,23 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 	strlcpy(tmp2, layout, sizeof(tmp2));
 	strlcpy(tmp2, TP_ParseFunChars(tmp2, false), sizeof(tmp2));
 	s = tmp2;
+
+	switch (BestWeaponFromStatItems(ti_cl->items)){
+		case IT_LIGHTNING:
+			a = ti_cl->cells;
+			break;
+		case IT_ROCKET_LAUNCHER:
+		case IT_GRENADE_LAUNCHER:
+			a = ti_cl->rockets;
+			break;
+		case IT_SUPER_NAILGUN:
+		case IT_NAILGUN:
+			a = ti_cl->nails;
+			break;
+		default:
+			a = ti_cl->shells;
+			break;
+	}
 
 	//
 	// parse/draw string like this "%n %h:%a %l %p %w"
@@ -299,10 +320,9 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 									else {
 										weap_str = TP_ItemName(BestWeaponFromStatItems(ti_cl->items));
 									}
-
 									char weap_white_stripped[32];
 									Util_SkipChars(weap_str, "{}", weap_white_stripped, 32);
-									Draw_SStringAligned(x, y, weap_white_stripped, scale, 1.0, proportional, (s[0] == 'W' ? text_align_right : text_align_left), x + 3 * font_width);
+									Draw_SStringAligned(x, y, weap_white_stripped, scale, 1.0, proportional, ((s[0] == 'W' || show_ammo) ? text_align_right : text_align_left), x + 3 * font_width);
 								}
 								x += 3 * font_width;
 								break;
@@ -315,27 +335,18 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 								x += 2 * font_width;
 								break;
 						}
+						if (show_ammo) {
+							if (!width_only) {
+								snprintf(tmp, sizeof(tmp), ":%d", a);
+								Draw_SStringAligned(x, y, tmp, scale, 1.0, proportional, text_align_left, x + 4 * font_width);
+								
+							}
+							x += 4 * font_width;
+						}
 						break;
 					case 'c': // draw ammo
 					case 'C': // draw ammo
 						if (!width_only) {
-							switch (BestWeaponFromStatItems(ti_cl->items)){
-								case IT_LIGHTNING:
-									a = ti_cl->cells;
-									break;
-								case IT_ROCKET_LAUNCHER:
-								case IT_GRENADE_LAUNCHER:
-									a = ti_cl->rockets;
-									break;
-								case IT_SUPER_NAILGUN:
-								case IT_NAILGUN:
-									a = ti_cl->nails;
-									break;
-								default:
-									a = ti_cl->shells;
-									break;
-							}
-
 							snprintf(tmp, sizeof(tmp), "%d", a);
 							Draw_SStringAligned(x, y, tmp, scale, 1.0, proportional, (s[0] == 'C' ? text_align_right : text_align_left), x + 3 * font_width);
 						}
@@ -638,7 +649,7 @@ void SCR_Draw_TeamInfo(void)
 	y = vid.height * 0.6 + scr_teaminfo_y.value;
 
 	// this does't draw anything, just calculate width
-	w = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
+	w = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
 	h = slots_num * scale;
 
 	for (j = 0; j < slots_num; j++) {
@@ -653,7 +664,7 @@ void SCR_Draw_TeamInfo(void)
 			Draw_AlphaRectangleRGB(x, y, w, h * FONTWIDTH, 0, true, RGBAVECT_TO_COLOR(col));
 		}
 
-		SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, y, maxname, maxloc, false, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
+		SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, y, maxname, maxloc, false, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
 
 		y += FONTWIDTH * scale;
 	}
@@ -766,6 +777,7 @@ void TeamInfo_HudInit(void)
 	Cvar_Register(&scr_shownick_name_width);
 	Cvar_Register(&scr_shownick_time);
 	Cvar_Register(&scr_shownick_proportional);
+	Cvar_Register(&scr_shownick_show_ammo);
 
 	Cvar_Register(&scr_teaminfo_order);
 	Cvar_Register(&scr_teaminfo_align_right);
@@ -780,6 +792,7 @@ void TeamInfo_HudInit(void)
 	Cvar_Register(&scr_teaminfo_powerup_style);
 	Cvar_Register(&scr_teaminfo_flag_style);
 	Cvar_Register(&scr_teaminfo_weapon_style);
+	Cvar_Register(&scr_teaminfo_show_ammo);
 	Cvar_Register(&scr_teaminfo_show_enemies);
 	Cvar_Register(&scr_teaminfo_show_self);
 	Cvar_Register(&scr_teaminfo_proportional);
@@ -796,6 +809,7 @@ void TeamInfo_HudInit(void)
 		"low_health", "25",
 		"armor_style", "3",
 		"weapon_style", "0",
+		"show_ammo", "0",
 		"show_enemies", "0",
 		"show_self", "1",
 		"show_headers", "1",
@@ -927,7 +941,7 @@ void SCR_Draw_ShowNick(void)
 	y = vid.height * 0.6 + scr_shownick_y.value;
 
 	// this does't draw anything, just calculate width
-	w = SCR_HudDrawTeamInfoPlayer(&shownick, 0, 0, maxname, maxloc, true, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
+	w = SCR_HudDrawTeamInfoPlayer(&shownick, 0, 0, maxname, maxloc, true, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_shownick_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
 	h = FONTWIDTH * scale;
 
 	x = (scr_shownick_align_right ? (vid.width - w) - FONTWIDTH : FONTWIDTH);
@@ -939,5 +953,5 @@ void SCR_Draw_ShowNick(void)
 	Draw_AlphaRectangleRGB(x, y, w, h, 0, true, RGBAVECT_TO_COLOR(col));
 
 	// draw shownick
-	SCR_HudDrawTeamInfoPlayer(&shownick, x, y, maxname, maxloc, false, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
+	SCR_HudDrawTeamInfoPlayer(&shownick, x, y, maxname, maxloc, false, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_shownick_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
 }

--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -271,8 +271,8 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 	}
 
 	txtclr = ti_cl->isdead == 2 ? "&c840" : "&cfff";
-	isDeadCA = ti_cl->isdead || (ktx_ca_wipeout && ti_cl->health <= 0);
-	isRespawning = ti_cl->isdead == 1 && ti_cl->timetospawn > 0 && ti_cl->timetospawn < 999;
+	isDeadCA = ti_cl->isdead;
+	isRespawning = isDeadCA && ti_cl->timetospawn > 0 && ti_cl->timetospawn < 999;
 	
 	if (isDeadCA) {
 		alpha = 0.25;

--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -270,7 +270,7 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 		return 0;
 	}
 
-	txtclr = ti_cl->isdead == 2 ? "&c840" : "&cfff";
+	txtclr = "&cfff";
 	isDeadCA = ti_cl->isdead;
 	isRespawning = isDeadCA && ti_cl->timetospawn > 0 && ti_cl->timetospawn < 999;
 	

--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -250,9 +250,13 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 {
 	extern cvar_t tp_name_rlg;
 	char *s, *loc, tmp[1024], tmp2[MAX_MACRO_STRING], *aclr, *txtclr;
+	char * ktxmode = Info_ValueForKey(cl.serverinfo, "mode"); // check KTX game mode
 	float x_in = x; // save x
 	int i, a;
 	qbool isDeadCA, isRespawning;
+	qbool ktx_ca = (strstr(ktxmode, "-ca") != NULL);
+	qbool ktx_wipeout = (strstr(ktxmode, "-wo") != NULL);
+	qbool ktx_ca_wipeout = (ktx_ca || ktx_wipeout);
 	mpic_t *pic;
 	float width;
 	float font_width = scale * FONT_WIDTH;
@@ -267,7 +271,7 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 	}
 
 	txtclr = ti_cl->isdead == 2 ? "&c840" : "&cfff";
-	isDeadCA = ti_cl->isdead || (ti_cl->camode == 1 && ti_cl->health <= 0); // camode == 1 means ca/wipeout
+	isDeadCA = ti_cl->isdead || (ktx_ca_wipeout && ti_cl->health <= 0);
 	isRespawning = ti_cl->isdead == 1 && ti_cl->timetospawn > 0 && ti_cl->timetospawn < 999;
 	
 	if (isDeadCA) {
@@ -366,8 +370,8 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 							x += 4 * font_width;
 						}
 						break;
-					case 'c': // draw ammo
-					case 'C': // draw ammo
+					case 'k': // draw ammo
+					case 'K': // draw ammo
 						if (!width_only) {
 							snprintf(tmp, sizeof(tmp), "%s%d", txtclr, a);
 							Draw_SStringAligned(x, y, tmp, scale, alpha, proportional, (s[0] == 'C' ? text_align_right : text_align_left), x + 3 * font_width);
@@ -506,7 +510,7 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 						break;
 
 					case 'p': // draw powerups
-						if (show_countdown && ti_cl->camode)
+						if (show_countdown && ktx_ca_wipeout)
 						{
 							if (!width_only) {
 								if (isRespawning)

--- a/hud_teaminfo.c
+++ b/hud_teaminfo.c
@@ -57,12 +57,13 @@ static cvar_t scr_teaminfo_powerup_style   = { "scr_teaminfo_powerup_style", "1"
 static cvar_t scr_teaminfo_flag_style      = { "scr_teaminfo_flag_style",  "1" };
 static cvar_t scr_teaminfo_weapon_style    = { "scr_teaminfo_weapon_style","1" };
 static cvar_t scr_teaminfo_show_ammo	   = { "scr_teaminfo_show_ammo","0" };
+static cvar_t scr_teaminfo_show_countdown  = { "scr_teaminfo_show_countdown","1" };
 static cvar_t scr_teaminfo_show_enemies    = { "scr_teaminfo_show_enemies","0" };
 static cvar_t scr_teaminfo_show_self       = { "scr_teaminfo_show_self",   "2" };
 static cvar_t scr_teaminfo_proportional    = { "scr_teaminfo_proportional", "0"};
 cvar_t scr_teaminfo                        = { "scr_teaminfo",             "1" };   // non-static for menu
 
-static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int show_ammo, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional);
+static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int show_ammo, int show_countdown, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional);
 
 static int HUD_CompareTeamInfoSlots(const void* lhs_, const void* rhs_)
 {
@@ -102,6 +103,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 		*hud_teaminfo_loc_width,
 		*hud_teaminfo_name_width,
 		*hud_teaminfo_show_ammo,
+		*hud_teaminfo_show_countdown,
 		*hud_teaminfo_show_enemies,
 		*hud_teaminfo_show_self,
 		*hud_teaminfo_show_headers,
@@ -124,6 +126,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 		hud_teaminfo_show_enemies = HUD_FindVar(hud, "show_enemies");
 		hud_teaminfo_show_self = HUD_FindVar(hud, "show_self");
 		hud_teaminfo_show_headers = HUD_FindVar(hud, "show_headers");
+		hud_teaminfo_show_countdown = HUD_FindVar(hud, "show_countdown");
 		hud_teaminfo_scale = HUD_FindVar(hud, "scale");
 		hud_teaminfo_armor_style = HUD_FindVar(hud, "armor_style");
 		hud_teaminfo_powerup_style = HUD_FindVar(hud, "powerup_style");
@@ -179,7 +182,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 	header_spacing = max(0, hud_teaminfo_header_spacing->value);
 
 	// this doesn't draw anything, just calculate width
-	width = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
+	width = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_show_countdown->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
 	height = FONTWIDTH * hud_teaminfo_scale->value * (hud_teaminfo_show_enemies->integer && hud_teaminfo_show_headers->integer ? slots_num + max(2 * n_teams - 1, 0) * header_spacing : slots_num);
 
 	if (hud_editor) {
@@ -222,7 +225,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 			for (j = 0; j < slots_num; j++) {
 				i = slots[j];
 				if (!strcmp(cl.players[i].team, sorted_teams[k].name)) {
-					SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
+					SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_show_countdown->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
 					_y += FONTWIDTH * hud_teaminfo_scale->value;
 				}
 			}
@@ -232,7 +235,7 @@ void SCR_HUD_DrawTeamInfo(hud_t *hud)
 	else {
 		for (j = 0; j < slots_num; j++) {
 			i = slots[j];
-			SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
+			SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, _y, maxname, maxloc, false, hud_teaminfo_scale->value, hud_teaminfo_layout->string, hud_teaminfo_weapon_style->integer, hud_teaminfo_show_ammo->integer, hud_teaminfo_show_countdown->integer, hud_teaminfo_armor_style->integer, hud_teaminfo_powerup_style->integer, hud_teaminfo_flag_style->integer, hud_teaminfo_low_health->integer, hud_teaminfo_proportional->integer);
 			_y += FONTWIDTH * hud_teaminfo_scale->value;
 		}
 	}
@@ -243,13 +246,13 @@ qbool Has_Both_RL_and_LG(int flags)
 	return (flags & IT_ROCKET_LAUNCHER) && (flags & IT_LIGHTNING);
 }
 
-static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int show_ammo, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional)
+static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int maxname, int maxloc, qbool width_only, float scale, const char* layout, int weapon_style, int show_ammo, int show_countdown, int armor_style, int powerup_style, int flag_style, int low_health, qbool proportional)
 {
 	extern cvar_t tp_name_rlg;
 	char *s, *loc, tmp[1024], tmp2[MAX_MACRO_STRING], *aclr, *txtclr;
 	float x_in = x; // save x
 	int i, a;
-	qbool isDeadCA;
+	qbool isDeadCA, isRespawning;
 	mpic_t *pic;
 	float width;
 	float font_width = scale * FONT_WIDTH;
@@ -264,7 +267,8 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 	}
 
 	txtclr = ti_cl->isdead == 2 ? "&c840" : "&cfff";
-	isDeadCA = ti_cl->isdead || (ti_cl->camode == 1 && ti_cl->health <= 0);	// camode == 1 means we're playing ca/wipeout
+	isDeadCA = ti_cl->isdead || (ti_cl->camode == 1 && ti_cl->health <= 0); // camode == 1 means ca/wipeout
+	isRespawning = ti_cl->isdead == 1 && ti_cl->timetospawn > 0 && ti_cl->timetospawn < 999;
 	
 	if (isDeadCA) {
 		alpha = 0.25;
@@ -373,7 +377,7 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 					case 'r': // draw respawn time
 					case 'R': // draw respawn time
 						if (!width_only) {
-							if (ti_cl->isdead == 1 && ti_cl->timetospawn > 0)
+							if (isRespawning)
 							{
 								snprintf(tmp, sizeof(tmp), "&cfa0%d", ti_cl->timetospawn);
 							}
@@ -502,66 +506,84 @@ static int SCR_HudDrawTeamInfoPlayer(ti_player_t *ti_cl, float x, int y, int max
 						break;
 
 					case 'p': // draw powerups
-						switch (powerup_style) {
-							case 1: // quad/pent/ring image
-								if (!width_only) {
-									if (ti_cl->items & IT_QUAD) {
-										Draw_SPic(x, y, sb_items[5], scale / 2);
-									}
-									x += font_width;
-									if (ti_cl->items & IT_INVULNERABILITY) {
-										Draw_SPic(x, y, sb_items[3], scale / 2);
-									}
-									x += font_width;
-									if (ti_cl->items & IT_INVISIBILITY) {
-										Draw_SPic(x, y, sb_items[2], scale / 2);
-									}
-									x += font_width;
+						if (show_countdown && ti_cl->camode)
+						{
+							if (!width_only) {
+								if (isRespawning)
+								{
+									snprintf(tmp, sizeof(tmp), "&cfa0%d ", ti_cl->timetospawn);
 								}
-								else { 
-									x += 3 * font_width;
+								else
+								{
+									snprintf(tmp, sizeof(tmp), "%s", " ");
 								}
-								break;
+								Draw_SStringAligned(x, y, tmp, scale * 0.75, 1.0, proportional, text_align_right, x + 3 * font_width);
+							}
+							x += 3 * font_width;
+							break;
+						}
+						else {
+							switch (powerup_style) {
+								case 1: // quad/pent/ring image
+									if (!width_only) {
+										if (ti_cl->items & IT_QUAD) {
+											Draw_SPic(x, y, sb_items[5], scale / 2);
+										}
+										x += font_width;
+										if (ti_cl->items & IT_INVULNERABILITY) {
+											Draw_SPic(x, y, sb_items[3], scale / 2);
+										}
+										x += font_width;
+										if (ti_cl->items & IT_INVISIBILITY) {
+											Draw_SPic(x, y, sb_items[2], scale / 2);
+										}
+										x += font_width;
+									}
+									else { 
+										x += 3 * font_width;
+									}
+									break;
 
-							case 2: // player powerup face
-								if (!width_only) {
-									if (sb_face_quad && (ti_cl->items & IT_QUAD)) {
-										Draw_SPic(x, y, sb_face_quad, scale / 3);
+								case 2: // player powerup face
+									if (!width_only) {
+										if (sb_face_quad && (ti_cl->items & IT_QUAD)) {
+											Draw_SPic(x, y, sb_face_quad, scale / 3);
+										}
+										x += font_width;
+										if (sb_face_invuln && (ti_cl->items & IT_INVULNERABILITY)) {
+											Draw_SPic(x, y, sb_face_invuln, scale / 3);
+										}
+										x += font_width;
+										if (sb_face_invis && (ti_cl->items & IT_INVISIBILITY)) {
+											Draw_SPic(x, y, sb_face_invis, scale / 3);
+										}
+										x += font_width;
 									}
-									x += font_width;
-									if (sb_face_invuln && (ti_cl->items & IT_INVULNERABILITY)) {
-										Draw_SPic(x, y, sb_face_invuln, scale / 3);
+									else {
+										x += 3 * font_width;
 									}
-									x += font_width;
-									if (sb_face_invis && (ti_cl->items & IT_INVISIBILITY)) {
-										Draw_SPic(x, y, sb_face_invis, scale / 3);
-									}
-									x += font_width;
-								}
-								else {
-									x += 3 * font_width;
-								}
-								break;
+									break;
 
-							case 3: // colored font (QPR)
-								if (!width_only) {
-									if (ti_cl->items & IT_QUAD) {
-										Draw_SString(x, y, "&c03fQ", scale, proportional);
+								case 3: // colored font (QPR)
+									if (!width_only) {
+										if (ti_cl->items & IT_QUAD) {
+											Draw_SString(x, y, "&c03fQ", scale, proportional);
+										}
+										x += font_width;
+										if (ti_cl->items & IT_INVULNERABILITY) {
+											Draw_SString(x, y, "&cf00P", scale, proportional);
+										}
+										x += font_width;
+										if (ti_cl->items & IT_INVISIBILITY) {
+											Draw_SString(x, y, "&cff0R", scale, proportional);
+										}
+										x += font_width;
 									}
-									x += font_width;
-									if (ti_cl->items & IT_INVULNERABILITY) {
-										Draw_SString(x, y, "&cf00P", scale, proportional);
+									else {
+										x += font_width;
 									}
-									x += font_width;
-									if (ti_cl->items & IT_INVISIBILITY) {
-										Draw_SString(x, y, "&cff0R", scale, proportional);
-									}
-									x += font_width;
-								}
-								else {
-									x += 3 * font_width;
-								}
-								break;
+									break;
+							}
 						}
 						break;
 
@@ -698,7 +720,7 @@ void SCR_Draw_TeamInfo(void)
 	y = vid.height * 0.6 + scr_teaminfo_y.value;
 
 	// this does't draw anything, just calculate width
-	w = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
+	w = SCR_HudDrawTeamInfoPlayer(&ti_clients[0], 0, 0, maxname, maxloc, true, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_show_ammo.integer, scr_teaminfo_show_countdown.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
 	h = slots_num * scale;
 
 	for (j = 0; j < slots_num; j++) {
@@ -713,7 +735,7 @@ void SCR_Draw_TeamInfo(void)
 			Draw_AlphaRectangleRGB(x, y, w, h * FONTWIDTH, 0, true, RGBAVECT_TO_COLOR(col));
 		}
 
-		SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, y, maxname, maxloc, false, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
+		SCR_HudDrawTeamInfoPlayer(&ti_clients[i], x, y, maxname, maxloc, false, scr_teaminfo_scale.value, scr_teaminfo_order.string, scr_teaminfo_weapon_style.integer, scr_teaminfo_show_ammo.integer, scr_teaminfo_show_countdown.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_teaminfo_proportional.integer);
 
 		y += FONTWIDTH * scale;
 	}
@@ -875,6 +897,7 @@ void TeamInfo_HudInit(void)
 	Cvar_Register(&scr_teaminfo_flag_style);
 	Cvar_Register(&scr_teaminfo_weapon_style);
 	Cvar_Register(&scr_teaminfo_show_ammo);
+	Cvar_Register(&scr_teaminfo_show_countdown);
 	Cvar_Register(&scr_teaminfo_show_enemies);
 	Cvar_Register(&scr_teaminfo_show_self);
 	Cvar_Register(&scr_teaminfo_proportional);
@@ -892,6 +915,7 @@ void TeamInfo_HudInit(void)
 		"armor_style", "3",
 		"weapon_style", "0",
 		"show_ammo", "0",
+		"show_countdown", "1",
 		"show_enemies", "0",
 		"show_self", "1",
 		"show_headers", "1",
@@ -1023,7 +1047,7 @@ void SCR_Draw_ShowNick(void)
 	y = vid.height * 0.6 + scr_shownick_y.value;
 
 	// this does't draw anything, just calculate width
-	w = SCR_HudDrawTeamInfoPlayer(&shownick, 0, 0, maxname, maxloc, true, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_shownick_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
+	w = SCR_HudDrawTeamInfoPlayer(&shownick, 0, 0, maxname, maxloc, true, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_shownick_show_ammo.integer, 0, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
 	h = FONTWIDTH * scale;
 
 	x = (scr_shownick_align_right ? (vid.width - w) - FONTWIDTH : FONTWIDTH);
@@ -1035,5 +1059,5 @@ void SCR_Draw_ShowNick(void)
 	Draw_AlphaRectangleRGB(x, y, w, h, 0, true, RGBAVECT_TO_COLOR(col));
 
 	// draw shownick
-	SCR_HudDrawTeamInfoPlayer(&shownick, x, y, maxname, maxloc, false, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_shownick_show_ammo.integer, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
+	SCR_HudDrawTeamInfoPlayer(&shownick, x, y, maxname, maxloc, false, scale, scr_shownick_order.string, scr_teaminfo_weapon_style.integer, scr_shownick_show_ammo.integer, 0, scr_teaminfo_armor_style.integer, scr_teaminfo_powerup_style.integer, scr_teaminfo_flag_style.integer, scr_teaminfo_low_health.integer, scr_shownick_proportional.integer);
 }

--- a/sbar.c
+++ b/sbar.c
@@ -1263,18 +1263,14 @@ static void Sbar_DeathmatchOverlay(int start)
 	char num[12];
 	char myminutes[11];
 	char fragsstr[10];
-	char * ktxmode = Info_ValueForKey(cl.serverinfo, "mode");
 	player_info_t *s;
 	ti_player_t *ti_cl;
 	mpic_t *pic;
 	float scale = 1.0f;
 	float alpha = 1.0f;
-	float ca_alpha = 1.0f;	// alpha value for scoreboard elements during clan arena / wipeout
+	float ca_alpha;	// alpha value for scoreboard elements during clan arena / wipeout
 	qbool proportional = scr_scoreboard_proportional.integer;
 	qbool any_flags = false;
-	qbool ktx_ca = (strstr(ktxmode, "-ca") != NULL);
-	qbool ktx_wipeout = (strstr(ktxmode, "-wo") != NULL);
-	qbool ktx_ca_wipeout = (ktx_ca || ktx_wipeout);
 	extern ti_player_t ti_clients[MAX_CLIENTS];
 
 	if (!start && hud_faderankings.value) {
@@ -1466,7 +1462,7 @@ static void Sbar_DeathmatchOverlay(int start)
 		k = fragsort[i];
 		s = &cl.players[k];
 		ti_cl = &ti_clients[k];
-		ca_alpha = (ktx_ca_wipeout && scr_scoreboard_wipeout.value && ti_cl->isdead) ? 0.25f : 1.0f; // fade dead players in CA/wipeout
+		ca_alpha = (check_ktx_ca_wo() && scr_scoreboard_wipeout.value && ti_cl->isdead) ? 0.25f : 1.0f; // fade dead players in CA/wipeout
 
 		if (!s->name[0]) {
 			continue;
@@ -1544,13 +1540,13 @@ static void Sbar_DeathmatchOverlay(int start)
 		myminutes[0] = '\0';
 
 		// overwrite time column with spawn times in KTX wipeout
-		if (ktx_wipeout && scr_scoreboard_wipeout.value && (ti_cl->isdead == 1) && (ti_cl->timetospawn > 0) && (ti_cl->timetospawn < 999)){
+		if (check_ktx_wo() && scr_scoreboard_wipeout.value && (ti_cl->isdead == 1) && (ti_cl->timetospawn > 0) && (ti_cl->timetospawn < 999)){
 			color.c = RGBA_TO_COLOR(0xFF, 0xAA, 0x00, 255);
 			snprintf(myminutes, sizeof(myminutes), "%d", ti_cl->timetospawn);
 			Draw_SColoredStringAligned(x, y, myminutes, &color, 1, scale * 0.85, alpha, proportional, text_align_right, x + 4 * FONT_WIDTH);
 		}
 
-		else if (!ktx_wipeout || !scr_scoreboard_wipeout.value)
+		else if (!check_ktx_wo() || !scr_scoreboard_wipeout.value)
 		{
 			snprintf(myminutes, sizeof(myminutes), "%i", total);
 
@@ -1621,7 +1617,7 @@ static void Sbar_DeathmatchOverlay(int start)
 		fragsint = bound(-999, s->frags, 9999); // limit to 4 symbols int
 		snprintf(fragsstr, sizeof(fragsstr), "%i", fragsint);
 		
-		if (ktx_ca_wipeout && scr_scoreboard_wipeout.value && ti_cl->isdead)
+		if (check_ktx_ca_wo() && scr_scoreboard_wipeout.value && ti_cl->isdead)
 		{
 			color.c = RGBA_TO_COLOR(85, 85, 85, 255 * ca_alpha);	// change team/name to gray transparent text if dead in ca/wipeout
 		}
@@ -1676,7 +1672,7 @@ static void Sbar_DeathmatchOverlay(int start)
 			}
 
 			// kills
-			if (ktx_wipeout && scr_scoreboard_wipeout.value)
+			if (check_ktx_wo() && scr_scoreboard_wipeout.value)
 			{
 				snprintf(num, sizeof(num), "%d", ti_cl->round_kills);
 				color.c = (ti_cl->round_kills == 0 ? RGBA_TO_COLOR(255, 255, 255, 255) : RGBA_TO_COLOR(0, 187, 68, 255));
@@ -1698,7 +1694,7 @@ static void Sbar_DeathmatchOverlay(int start)
 			}
 
 			// deaths
-			if (ktx_wipeout && scr_scoreboard_wipeout.value)
+			if (check_ktx_wo() && scr_scoreboard_wipeout.value)
 			{
 				snprintf(num, sizeof(num), "%d", ti_cl->round_deaths);
 				color.c = (ti_cl->round_deaths == 0 ? RGBA_TO_COLOR(255, 255, 255, 255) : RGBA_TO_COLOR(255, 0, 0, 255));

--- a/sbar.c
+++ b/sbar.c
@@ -1262,11 +1262,15 @@ static void Sbar_DeathmatchOverlay(int start)
 	char myminutes[11];
 	char fragsstr[10];
 	player_info_t *s;
+	ti_player_t *ti_cl;
 	mpic_t *pic;
 	float scale = 1.0f;
 	float alpha = 1.0f;
+	float ca_alpha = 1.0f;
 	qbool proportional = scr_scoreboard_proportional.integer;
 	qbool any_flags = false;
+
+	extern ti_player_t ti_clients[MAX_CLIENTS];
 
 	if (!start && hud_faderankings.value) {
 		Draw_FadeScreen(hud_faderankings.value);
@@ -1456,6 +1460,8 @@ static void Sbar_DeathmatchOverlay(int start)
 
 		k = fragsort[i];
 		s = &cl.players[k];
+		ti_cl = &ti_clients[k];
+		ca_alpha = ti_cl->isdead ? 0.25f : 1.0f;
 
 		if (!s->name[0]) {
 			continue;
@@ -1539,7 +1545,7 @@ static void Sbar_DeathmatchOverlay(int start)
 			}
 		}
 
-		Draw_SColoredStringAligned(x, y, myminutes, &color, 1, scale, alpha, proportional, text_align_right, x + 4 * FONT_WIDTH);
+		Draw_SColoredStringAligned(x, y, myminutes, &color, 1, scale, alpha * ca_alpha, proportional, text_align_right, x + 4 * FONT_WIDTH);
 		x += 5 * FONT_WIDTH;
 
 		// draw spectator
@@ -1586,8 +1592,9 @@ static void Sbar_DeathmatchOverlay(int start)
 		}
 
 		// print the shirt/pants colour bars
-		Draw_Fill(cl.teamplay ? tempx - 40 : tempx, y + 4 - colors_thickness, 40, colors_thickness, Sbar_TopColorScoreboard(s));
-		Draw_Fill(cl.teamplay ? tempx - 40 : tempx, y + 4, 40, 4, Sbar_BottomColorScoreboard(s));
+		// use Draw_AlphaFill with additional alpha arg for wipeout deaths
+		Draw_AlphaFill(cl.teamplay ? tempx - 40 : tempx, y + 4 - colors_thickness, 40, colors_thickness, Sbar_TopColorScoreboard(s), ca_alpha);
+		Draw_AlphaFill(cl.teamplay ? tempx - 40 : tempx, y + 4, 40, 4, Sbar_BottomColorScoreboard(s), ca_alpha);
 
 		// frags
 		if (Sbar_ShowScoreboardIndicator() && k == mynum) {
@@ -1605,17 +1612,17 @@ static void Sbar_DeathmatchOverlay(int start)
 
 		// team
 		if (cl.teamplay) {
-			Draw_SColoredStringAligned(x, y, s->team, &color, 1, scale, alpha, proportional, text_align_center, x + 4 * FONT_WIDTH);
+			Draw_SColoredStringAligned(x, y, s->team, &color, 1, scale, alpha * ca_alpha, proportional, text_align_center, x + 4 * FONT_WIDTH);
 			x += 5 * FONT_WIDTH;
 		}
 
 		if (s->loginname[0] && scr_scoreboard_login_indicator.string[0]) {
 			mpic_t* flag = CL_LoginFlag(s->loginflag_id);
 			if (s->loginflag[0] && flag) {
-				Draw_FitPicAlphaCenter(x - FONT_WIDTH * 0.75, y, FONT_WIDTH * 1.6, FONT_WIDTH, flag, 1.0f);
+				Draw_FitPicAlphaCenter(x - FONT_WIDTH * 0.75, y, FONT_WIDTH * 1.6, FONT_WIDTH, flag, 1.0f * ca_alpha);
 			}
 			else {
-				Draw_SStringAligned(x - FONT_WIDTH * 0.75, y, scr_scoreboard_login_indicator.string, scale, alpha, proportional, text_align_center, x + FONT_WIDTH * 1.6);
+				Draw_SStringAligned(x - FONT_WIDTH * 0.75, y, scr_scoreboard_login_indicator.string, scale, alpha * ca_alpha, proportional, text_align_center, x + FONT_WIDTH * 1.6);
 			}
 		}
 		if (any_flags) {
@@ -1624,14 +1631,14 @@ static void Sbar_DeathmatchOverlay(int start)
 		if (s->loginname[0] && scr_scoreboard_login_names.integer) {
 			if (scr_scoreboard_login_color.string[0]) {
 				color.c = RGBAVECT_TO_COLOR(scr_scoreboard_login_color.color);
-				Draw_SColoredStringAligned(x, y, s->loginname, &color, 1, scale, alpha, proportional, text_align_left, x + FONT_WIDTH * 15);
+				Draw_SColoredStringAligned(x, y, s->loginname, &color, 1, scale, alpha * ca_alpha, proportional, text_align_left, x + FONT_WIDTH * 15);
 			}
 			else {
-				Draw_SStringAligned(x, y, s->loginname, scale, alpha, proportional, text_align_left, x + FONT_WIDTH * 15);
+				Draw_SStringAligned(x, y, s->loginname, scale, alpha * ca_alpha, proportional, text_align_left, x + FONT_WIDTH * 15);
 			}
 		}
 		else {
-			Draw_SStringAligned(x, y, s->name, scale, alpha, proportional, text_align_left, x + FONT_WIDTH * 15);
+			Draw_SStringAligned(x, y, s->name, scale, alpha * ca_alpha, proportional, text_align_left, x + FONT_WIDTH * 15);
 		}
 
 		if (statswidth) {

--- a/sbar.c
+++ b/sbar.c
@@ -1493,7 +1493,7 @@ static void Sbar_DeathmatchOverlay(int start)
 			background = RGBA_TO_COLOR(0, 255, 0, (byte)(bk_alpha * 255));
 		}
 		else {
-			background = RGBA_TO_COLOR(host_basepal[c * 3], host_basepal[c * 3 + 1], host_basepal[c * 3 + 2], (byte)(bk_alpha * ca_alpha * 255));
+			background = RGBA_TO_COLOR(host_basepal[c * 3], host_basepal[c * 3 + 1], host_basepal[c * 3 + 2], (byte)(bk_alpha * 255));
 		}
 
 		Draw_AlphaFillRGB(xofs, y, rank_width, skip, background);
@@ -1544,7 +1544,7 @@ static void Sbar_DeathmatchOverlay(int start)
 		myminutes[0] = '\0';
 
 		// overwrite time column with spawn times in KTX wipeout
-		if (ktx_wipeout && scr_scoreboard_wipeout.value && ti_cl->isdead && (ti_cl->timetospawn > 0) && (ti_cl->timetospawn < 999)){
+		if (ktx_wipeout && scr_scoreboard_wipeout.value && (ti_cl->isdead == 1) && (ti_cl->timetospawn > 0) && (ti_cl->timetospawn < 999)){
 			color.c = RGBA_TO_COLOR(0xFF, 0xAA, 0x00, 255);
 			snprintf(myminutes, sizeof(myminutes), "%d", ti_cl->timetospawn);
 			Draw_SColoredStringAligned(x, y, myminutes, &color, 1, scale * 0.85, alpha, proportional, text_align_right, x + 4 * FONT_WIDTH);

--- a/sbar.c
+++ b/sbar.c
@@ -1543,8 +1543,9 @@ static void Sbar_DeathmatchOverlay(int start)
 
 		// overwrite time column with spawn times in KTX wipeout
 		if ((ktx_wipeout) && (ti_cl->isdead) && (ti_cl->timetospawn > 0) && (ti_cl->timetospawn < 999)){
-			color.c = RGBA_TO_COLOR(255, 255, 0, 255);
+			color.c = RGBA_TO_COLOR(0xFF, 0xAA, 0x00, 255);
 			snprintf(myminutes, sizeof(myminutes), "%d", ti_cl->timetospawn);
+			Draw_SColoredStringAligned(x, y, myminutes, &color, 1, scale * 0.85, alpha, proportional, text_align_right, x + 4 * FONT_WIDTH);
 		}
 
 		else if (!ktx_wipeout)
@@ -1557,9 +1558,10 @@ static void Sbar_DeathmatchOverlay(int start)
 					snprintf(myminutes, sizeof(myminutes), "afk");
 				}
 			}
+
+			Draw_SColoredStringAligned(x, y, myminutes, &color, 1, scale, alpha, proportional, text_align_right, x + 4 * FONT_WIDTH);
 		}
 
-		Draw_SColoredStringAligned(x, y, myminutes, &color, 1, scale, alpha, proportional, text_align_right, x + 4 * FONT_WIDTH);
 		x += 5 * FONT_WIDTH;
 
 		// draw spectator

--- a/screen.h
+++ b/screen.h
@@ -147,6 +147,9 @@ typedef struct ti_player_s {
 	int			nails;
 	int			rockets;
 	int 		cells;
+	int			camode;
+	int			isdead;
+	int			timetospawn;
 	char		nick[TEAMINFO_NICKLEN]; // yeah, nick is nick, must be short
 	double		time; // when we recive last update about this player, so we can guess disconnects and etc
 

--- a/screen.h
+++ b/screen.h
@@ -150,6 +150,8 @@ typedef struct ti_player_s {
 	int			camode;
 	int			isdead;
 	int			timetospawn;
+	int			round_kills;
+	int			round_deaths;
 	char		nick[TEAMINFO_NICKLEN]; // yeah, nick is nick, must be short
 	double		time; // when we recive last update about this player, so we can guess disconnects and etc
 

--- a/screen.h
+++ b/screen.h
@@ -143,6 +143,10 @@ typedef struct ti_player_s {
 	int			items;
 	int			health;
 	int			armor;
+	int			shells;
+	int			nails;
+	int			rockets;
+	int 		cells;
 	char		nick[TEAMINFO_NICKLEN]; // yeah, nick is nick, must be short
 	double		time; // when we recive last update about this player, so we can guess disconnects and etc
 

--- a/utils.c
+++ b/utils.c
@@ -362,6 +362,32 @@ int HexToInt(char c)
 		return -1;
 }
 
+/************************************** Game Mode Utils *********************************/
+
+char *get_ktx_mode (void)
+{
+	return Info_ValueForKey(cl.serverinfo, "mode");
+}
+
+qbool check_ktx_ca (void)	// playing clan arena
+{
+	char *ktxmode = get_ktx_mode();
+
+	return (strstr(ktxmode, "-ca") != NULL);
+}
+
+qbool check_ktx_wo (void)	// playing wipeout
+{
+	char *ktxmode = get_ktx_mode();
+
+	return (strstr(ktxmode, "-wo") != NULL);
+}
+
+qbool check_ktx_ca_wo (void) // playing clan arena or wipeout
+{
+	return (check_ktx_ca() || check_ktx_wo());
+}
+
 /************************************** File Utils **************************************/
 
 int Util_Extend_Filename(char *filename, char **ext) {

--- a/utils.h
+++ b/utils.h
@@ -55,6 +55,15 @@ char *str_trim(char *str);
 int HexToInt(char c);
 
 ///
+/// Game Mode utils
+///
+
+char *get_ktx_mode(void);
+qbool check_ktx_ca(void);
+qbool check_ktx_wo(void);
+qbool check_ktx_ca_wo(void);
+
+///
 /// Filename utils
 ///
 


### PR DESCRIPTION
- Implemented scr_shownick_show_ammo to display ammo in /shownick 1
- can also use %k or %K in format string to customize ammo display
- lots of teaminfo stuff: respawn times and dead players while playing ca/wipeout
- Scoreboard kills/deaths reset between rounds in wipeout
- Scoreboard replaces server time with respawn time during wipeout
- Scoreboard dims dead players in ca/wipeout