### PR TITLE
SMACKDOWN: allow gl_outline and particle/custom LG

### DIFF
--- a/help_cmdline_params.json
+++ b/help_cmdline_params.json
@@ -1,8 +1,5 @@
 {
   "-allowmultiple": {
-    "builds": [
-      "debug"
-    ],
     "description": "On Windows, launch multiple copies of ezQuake rather than re-using the existing instance",
     "systems": [
       "windows"

--- a/rulesets.c
+++ b/rulesets.c
@@ -96,8 +96,7 @@ qbool RuleSets_DisallowModelOutline(struct model_s *mod)
 		case MOD_BACKPACK:
 			return !cls.demoplayback && (rulesetDef.ruleset == rs_qcon || rulesetDef.ruleset == rs_smackdown);
 		default:
-			// return to just rs_qcon once backface outlining tested
-			return !cls.demoplayback && (rulesetDef.ruleset == rs_qcon || rulesetDef.ruleset == rs_smackdown);
+			return !cls.demoplayback && (rulesetDef.ruleset == rs_qcon);
 	}
 }
 
@@ -237,7 +236,7 @@ static void Rulesets_Smackdown(qbool enable)
 		rulesetDef.maxfps = 77;
 		rulesetDef.restrictTriggers = true;
 		rulesetDef.restrictPacket = true; // packet command could have been exploited for external timers
-		rulesetDef.restrictParticles = true;
+		rulesetDef.restrictParticles = false;
 		rulesetDef.restrictLogging = true;
 		rulesetDef.restrictRollAngle = true;
 		rulesetDef.ruleset = rs_smackdown;


### PR DESCRIPTION
Hopefully this isn't too controversial. These changes have been a long time coming: gl_outline was excluded due to a bug that has now been fixed for almost two years, and custom LGs models are a non-issue now that everyone uses fakeshaft anyway. These are both popular features and many would appreciate the update.