### PR TITLE
NET: Support FTE transparency extension.

### DIFF
--- a/cl_ents.c
+++ b/cl_ents.c
@@ -1366,7 +1366,19 @@ void CL_ParsePlayerinfo (void)
 	} 
 	else 
 	{
-		flags = state->flags = MSG_ReadShort ();
+		flags = (unsigned short) MSG_ReadShort ();
+
+		if (cls.fteprotocolextensions & FTE_PEXT_TRANS)
+		{
+			if (flags & PF_EXTRA_PFS)
+				flags |= MSG_ReadByte() << 16;
+		}
+		else
+		{
+			flags = (flags & 0x3fff) | ((flags & 0xc000) << 8);
+		}
+
+		state->flags = flags;
 
 		state->messagenum = cl.parsecount;
 		if (cls.mvdprotocolextensions1 & MVD_PEXT1_FLOATCOORDS) {

--- a/protocol.h
+++ b/protocol.h
@@ -285,8 +285,8 @@ void MSG_DecodeMVDSVWeaponFlags(int flags, int* weaponmode, int* weaponhide, qbo
 // bits 11..13 are player move type bits (ZQuake extension)
 #define PF_PMC_SHIFT	11
 #define	PF_PMC_MASK		7
-#define	PF_ONGROUND		(1<<14)			// ZQuake extension
-#define	PF_SOLID		(1<<15)			// ZQuake extension
+#define	PF_ONGROUND		(1<<22)			// ZQuake extension, 14 but offset due to TRANS
+#define	PF_SOLID		(1<<23)			// ZQuake extension, 15 but offset due to TRANS
 
 // encoded player move types
 #define PMC_NORMAL				0		// normal ground movement
@@ -352,6 +352,8 @@ void MSG_DecodeMVDSVWeaponFlags(int flags, int* weaponmode, int* weaponhide, qbo
 
 #ifdef PROTOCOL_VERSION_FTE
 #define U_FTE_EVENMORE	(1<<7)		//extension info follows
+
+#define PF_EXTRA_PFS    (1<<15)
 
 //fte extensions
 //EVENMORE flags


### PR DESCRIPTION
This is a straight port from the FTE client implementation on top of the support that was already in ezQuake.

https://github.com/fte-team/fteqw/blob/16c8e521ef8fe1a8d47dcaa36207cd5eb0f09dce/engine/common/protocol.h#L600-L601

https://github.com/fte-team/fteqw/blob/16c8e521ef8fe1a8d47dcaa36207cd5eb0f09dce/engine/client/cl_ents.c#L4929-L4939

This fixes the network part of #630 