### PR TITLE
Allow gl_outline in smackdown

### DIFF
--- a/gl_framebuffer.c
+++ b/gl_framebuffer.c
@@ -476,7 +476,7 @@ qbool GL_FramebufferStartWorldNormals(framebuffer_id id)
 	GLenum buffers[2] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
 	float clearValue[] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
-	if (!r_fx_geometry.integer || !GL_Supported(R_SUPPORT_FRAMEBUFFERS)) {
+	if (!r_fx_geometry.integer || !GL_Supported(R_SUPPORT_FRAMEBUFFERS) || !RuleSets_AllowEdgeOutline()) {
 		return false;
 	}
 

--- a/gl_framebuffer.c
+++ b/gl_framebuffer.c
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "r_texture.h"
 #include "gl_texture_internal.h"
 #include "r_renderer.h"
+#include "rulesets.h"
 
 extern cvar_t vid_framebuffer;
 extern cvar_t vid_framebuffer_depthformat;

--- a/help_variables.json
+++ b/help_variables.json
@@ -5147,9 +5147,9 @@
     },
     "gl_outline": {
       "default": "0",
-      "desc": "Controls outlining of models and map.",
+      "desc": "Controls outlining of models and map. Disallowed in qcon ruleset.",
       "group-id": "35",
-      "remarks": "Outlining of the world is only valid when cheats are enabled.",
+      "remarks": "See /r_fx_geometry for edge outlining of the map.",
       "type": "enum",
       "values": [
         {
@@ -5161,7 +5161,7 @@
           "name": "1"
         },
         {
-          "description": "Outline world",
+          "description": "Outline world (used only for map development)",
           "name": "2"
         },
         {
@@ -15653,9 +15653,9 @@
     },
     "r_fx_geometry": {
       "default": "0",
-      "desc": "Outlines the world based on surface normals.",
+      "desc": "Outlines the world based on surface normals. Disallowed in qcon ruleset.",
       "group-id": "35",
-      "remarks": "Requires vid_framebuffer 1|2 and Modern OpenGL (vid_renderer 1).",
+      "remarks": "Requires vid_framebuffer 1|2 and Modern OpenGL (vid_renderer 1). See /gl_outline for model outline",
       "type": "boolean"
     },
     "r_glstats": {

--- a/menu_options.c
+++ b/menu_options.c
@@ -180,7 +180,7 @@ const char* scr_sshot_format_enum[] = {
 extern cvar_t mvd_autotrack, mvd_moreinfo, mvd_status, cl_weaponpreselect, cl_weaponhide, con_funchars_mode, con_notifytime, scr_consize, ignore_opponents, _con_notifylines,
 	ignore_qizmo_spec, ignore_spec, msg_filter, crosshair, crosshairsize, cl_smartjump, scr_coloredText,
 	cl_rollangle, cl_rollspeed, v_gunkick, v_kickpitch, v_kickroll, v_kicktime, v_viewheight, match_auto_sshot, match_auto_record, match_auto_logconsole,
-	r_fastturb, r_grenadetrail, cl_drawgun, r_viewmodelsize, r_viewmodeloffset, scr_clock, scr_gameclock, show_fps, rate, cl_c2sImpulseBackup,
+	r_fastturb, r_grenadetrail, cl_drawgun, r_viewmodelsize, r_viewmodeloffset, gl_outline, scr_clock, scr_gameclock, show_fps, rate, cl_c2sImpulseBackup,
 	name, team, skin, topcolor, bottomcolor, cl_teamtopcolor, cl_teambottomcolor, cl_teamquadskin, cl_teampentskin, cl_teambothskin, /*cl_enemytopcolor, cl_enemybottomcolor, */
 	cl_enemyquadskin, cl_enemypentskin, cl_enemybothskin, demo_dir, qizmo_dir, qwdtools_dir, cl_fakename, cl_fakename_suffix,
 	cl_chatsound, con_sound_mm1_volume, con_sound_mm2_volume, con_sound_spec_volume, con_sound_other_volume, s_khz, s_desiredsamples,
@@ -188,6 +188,10 @@ extern cvar_t mvd_autotrack, mvd_moreinfo, mvd_status, cl_weaponpreselect, cl_we
 	enemyforceskins, teamforceskins, vid_vsync_lag_fix, cl_sayfilter_coloredtext, cl_sayfilter_sendboth,
 	mvd_autotrack_lockteam, qtv_adjustbuffer, cl_earlypackets, cl_useimagesinfraglog, con_completion_format, menu_ingame, sys_inactivesound
 ;
+#ifdef RENDERER_OPTION_MODERN_OPENGL
+extern cvar_t r_fx_geometry;
+#endif
+
 #ifdef _WIN32
 extern cvar_t demo_format, sys_highpriority, cl_window_caption, vid_flashonactivity;
 void Sys_RegisterQWURLProtocol_f(void);
@@ -350,6 +354,9 @@ const char* explosiontype_enum[] =
 
 const char* muzzleflashes_enum[] =
 { "off", "on", "own off" };
+
+const char* outline_enum[] =
+{ "off", "models", "world", "models+world" };
 
 const char* simpleitemsorientation_enum[] =
 {"Parallel upright", "Facing upright", "Parallel", "Oriented"};
@@ -932,6 +939,7 @@ setting settfps_arr[] = {
 	ADDSET_ADVANCED_SECTION(),
 	ADDSET_NUMBER	("Weapon Shift", r_viewmodeloffset, -10, 10, 1),
 	ADDSET_NAMED	("Weapon Muzzleflashes", cl_muzzleflash, muzzleflashes_enum),
+	ADDSET_NAMED	("Outline", gl_outline, outline_enum),
 	ADDSET_BASIC_SECTION(),
 	
 	ADDSET_SEPARATOR("Environment"),
@@ -948,6 +956,9 @@ setting settfps_arr[] = {
 	ADDSET_BOOL		("Gib Filter", cl_gibfilter),
 	ADDSET_ADVANCED_SECTION(),
 	ADDSET_NAMED	("Dead Body Filter", cl_deadbodyfilter, deadbodyfilter_enum),
+#ifdef RENDERER_OPTION_MODERN_OPENGL
+	ADDSET_BOOL		("Outline", r_fx_geometry),
+#endif
 	ADDSET_BASIC_SECTION(),
 	
 	ADDSET_SEPARATOR("Projectiles"),

--- a/rulesets.c
+++ b/rulesets.c
@@ -81,6 +81,7 @@ qbool RuleSets_DisallowSimpleTexture(model_t* mod)
 	}
 }
 
+// for models (gl_outline)
 qbool RuleSets_DisallowModelOutline(struct model_s *mod)
 {
 	if (mod == NULL) {
@@ -90,14 +91,25 @@ qbool RuleSets_DisallowModelOutline(struct model_s *mod)
 
 	switch (mod->modhint) {
 		case MOD_EYES:
-			return true;
 		case MOD_THUNDERBOLT:
 			return true;
 		case MOD_BACKPACK:
 			return !cls.demoplayback && (rulesetDef.ruleset == rs_qcon || rulesetDef.ruleset == rs_smackdown);
 		default:
 			// return to just rs_qcon once backface outlining tested
-			return !cls.demoplayback && (rulesetDef.ruleset == rs_qcon || rulesetDef.ruleset == rs_smackdown);
+//			return !cls.demoplayback && (rulesetDef.ruleset == rs_qcon || rulesetDef.ruleset == rs_smackdown);
+			return !cls.demoplayback && (rulesetDef.ruleset == rs_qcon);
+	}
+}
+
+// for edges (r_fx_geometry)
+qbool RuleSets_AllowEdgeOutline(void)
+{
+	switch(rulesetDef.ruleset) {
+		case rs_qcon:
+			return false;
+		default:
+			return true;
 	}
 }
 

--- a/rulesets.h
+++ b/rulesets.h
@@ -61,6 +61,7 @@ qbool Ruleset_BlockHudPicChange(void);
 qbool Ruleset_AllowPolygonOffset(entity_t* ent);
 qbool Rulesets_AllowAlternateModel(const char* modelName);
 qbool RuleSets_DisallowModelOutline(struct model_s *mod);
+qbool RuleSets_AllowEdgeOutline(void);
 qbool RuleSets_DisallowExternalTexture(struct model_s *mod);
 qbool Ruleset_IsLumaAllowed(struct model_s *mod);
 qbool Ruleset_AllowPowerupShell(struct model_s* mod);


### PR DESCRIPTION
Allow `/gl_outline` in smackdown ruleset, just like `/r_fx_geometry`.
Disallow both in qcon ruleset.

2 new entry in the Options for these two outline settings