### PR TITLE
MINOR: Warn on empty textures rather than break.

### DIFF
--- a/src/r_brushmodel_load.c
+++ b/src/r_brushmodel_load.c
@@ -491,6 +491,10 @@ static void Mod_LoadTextures(model_t* mod, lump_t *l, byte* mod_base)
 		if (tx->width < 0 || tx->height < 0) {
 			Host_Error("Texture %s negative dimensions: %dx%d", tx->name, tx->width, tx->height);
 		}
+		if (tx->width == 0 || tx->height == 0) {
+			Con_Printf("Warning: Skipping zero size texture %s in %s\n", tx->name, mod->name);
+			continue;
+		}
 		if (tx->width > INT_MAX / tx->height / 3) {
 			Host_Error("Texture %s excessive size: %dx%d", tx->name, tx->width, tx->height);
 		}


### PR DESCRIPTION
This is a common annoyance when TrenchBroom inserts a __TB_Empty texture due to some action when mapping. The result is that the size check later on causes a division by zero which crashes ezQuake without giving any actionable feedback to the user.