### PR TITLE
INPUT: don't initialize joystick/perform any logic unless cvar has been set, other input initialization fixes

### DIFF
--- a/src/vid_sdl2.c
+++ b/src/vid_sdl2.c
@@ -271,10 +271,10 @@ static void IN_SnapMouseBackToCentre(void)
 
 static void in_raw_callback(cvar_t *var, char *value, qbool *cancel)
 {
-	if (var == &in_raw)
+	if ((var == &in_raw) && (atoi(value) != in_raw.value)) {
 		Cvar_SetValue(&in_raw, atoi(value));
-
-	IN_Restart_f();
+		IN_Restart_f();
+	}
 }
 
 static void in_grab_windowed_mouse_callback(cvar_t *val, char *value, qbool *cancel)

--- a/src/vid_sdl2.c
+++ b/src/vid_sdl2.c
@@ -1917,6 +1917,7 @@ static void VID_UpdateConRes(void)
 	vid.numpages = 2; // ??
 	Draw_AdjustConback();
 	vid.recalc_refdef = 1;
+	Con_CheckResize();
 }
 
 void GL_FramebufferSetFiltering(qbool linear);


### PR DESCRIPTION
… it enabled, toggling joystick cvar to 1 initializes joystick device(s)