### PR TITLE
Add cl_maxfps_menu

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1830,7 +1830,13 @@
     },
     "cl_maxfps": {
       "default": "0",
-      "desc": "This variable sets the maximum limit for frames-per-second. Please see vid_vsync, cl_independentphysics, and cl_physfps.",
+      "desc": "This variable sets the maximum limit for frames-per-second while in-game. Please see cl_maxfps_menu, vid_vsync, cl_independentphysics, and cl_physfps.",
+      "group-id": "8",
+      "type": "float"
+    },
+    "cl_maxfps_menu": {
+      "default": "0",
+      "desc": "This variable sets the maximum limit for frames-per-second while disconnected, has a minimum of 30, set lower to use display frequency.",
       "group-id": "8",
       "type": "float"
     },

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -143,6 +143,7 @@ static cvar_t cl_sv_packetsync = { "cl_sv_packetsync", "1" };
 cvar_t	cl_sbar		= {"cl_sbar", "0"};
 cvar_t	cl_hudswap	= {"cl_hudswap", "0"};
 cvar_t	cl_maxfps	= {"cl_maxfps", "0"};
+cvar_t	cl_maxfps_menu	= {"cl_maxfps_menu", "0"};
 cvar_t	cl_physfps	= {"cl_physfps", "0"};	//#fps
 cvar_t	cl_physfps_spectator = {"cl_physfps_spectator", "77"};
 cvar_t  cl_independentPhysics = {"cl_independentPhysics", "1", 0, Rulesets_OnChange_indphys};
@@ -1738,6 +1739,7 @@ static void CL_InitLocal(void)
 	Cvar_Register(&cl_newlerp);
 	Cvar_Register(&cl_lerp_monsters);
 	Cvar_Register(&cl_maxfps);
+	Cvar_Register(&cl_maxfps_menu);
 	Cvar_Register(&cl_physfps);
 	Cvar_Register(&hud_fps_min_reset_interval);
 	Cvar_Register(&hud_frametime_max_reset_interval);
@@ -2113,8 +2115,11 @@ static double CL_MinFrameTime (void)
 	if (cls.timedemo || Movie_IsCapturing())
 		return 0;
 
-	if (cls.state == ca_disconnected || (Minimized && !cls.download))
-		return 1 / 30.0;
+	if ((cls.state == ca_disconnected) || (Minimized && !cls.download))
+		if (cl_maxfps_menu.value >= 30)
+			return 1 / cl_maxfps_menu.value;
+		else
+			return 1 / (r_displayRefresh.autoString ? atoi(r_displayRefresh.autoString) : 30.0);
 
 	if (cls.demoplayback)
 	{

--- a/src/vid_sdl2.c
+++ b/src/vid_sdl2.c
@@ -1120,6 +1120,7 @@ static void VID_SetupResolution(void)
 			Cvar_LatchedSetValue(&vid_width, 1024);
 			Cvar_LatchedSetValue(&vid_height, 768);
 			Cvar_LatchedSetValue(&r_displayRefresh, 0);
+
 			return;
 		}
 
@@ -1516,6 +1517,15 @@ static void VID_SDL_Init(void)
 #endif
 
 	R_Initialise();
+
+	//always get/set refresh rate
+	SDL_DisplayMode display_mode;
+	int display_nbr;
+
+	display_nbr = VID_DisplayNumber(true);
+	if (SDL_GetDesktopDisplayMode(display_nbr, &display_mode) == 0) {
+		Cvar_AutoSetInt(&r_displayRefresh, display_mode.refresh_rate);
+	}
 
 	glConfig.initialized = true;
 }


### PR DESCRIPTION
Adds the command cl_maxfps_menu, defaults to using the refresh rate
still caps at 30 when minimised