### PR TITLE
CVAR - disable gl_hwblend by default

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -4895,7 +4895,7 @@
       "type": "float"
     },
     "gl_hwblend": {
-      "default": "1",
+      "default": "0",
       "desc": "Toggles between OpenGL and Hardware palette changing.",
       "group-id": "39",
       "remarks": "1 can be slow on WinNT/2K.",

--- a/misc/cfg/gfx_gl_eyecandy.cfg
+++ b/misc/cfg/gfx_gl_eyecandy.cfg
@@ -149,7 +149,6 @@ gl_colorlights               "1"
 //Screen & Powerup Blends
 cl_bonusflash                "0"
 gl_cshiftpercent             "0"
-gl_hwblend                   "1"
 gl_polyblend                 "1"
 gl_powerupshells             "1"
 v_contentblend               "0"

--- a/misc/cfg/gfx_gl_faithful.cfg
+++ b/misc/cfg/gfx_gl_faithful.cfg
@@ -149,7 +149,6 @@ gl_colorlights               "0"
 //Screen & Powerup Blends
 cl_bonusflash                "0"
 gl_cshiftpercent             "100"
-gl_hwblend                   "1"
 gl_polyblend                 "0"
 gl_powerupshells             "0"
 v_contentblend               "0.33"

--- a/misc/cfg/gfx_gl_fast.cfg
+++ b/misc/cfg/gfx_gl_fast.cfg
@@ -149,7 +149,6 @@ gl_colorlights               "0"
 //Screen & Powerup Blends
 cl_bonusflash                "0"
 gl_cshiftpercent             "100"
-gl_hwblend                   "1"
 gl_polyblend                 "0"
 gl_powerupshells             "0"
 v_contentblend               "0"

--- a/misc/cfg/gfx_gl_higheyecandy.cfg
+++ b/misc/cfg/gfx_gl_higheyecandy.cfg
@@ -149,7 +149,6 @@ gl_colorlights               "1"
 //Screen & Powerup Blends
 cl_bonusflash                "0"
 gl_cshiftpercent             "100"
-gl_hwblend                   "1"
 gl_polyblend                 "0"
 gl_powerupshells             "1"
 v_contentblend               "1"

--- a/src/cl_view.c
+++ b/src/cl_view.c
@@ -252,7 +252,7 @@ cshift_t	cshift_slime = { {0,25,5}, 150 };
 cshift_t	cshift_lava = { {255,80,0}, 150 };
 
 cvar_t		gl_cshiftpercent = {"gl_cshiftpercent", "100"};
-cvar_t		gl_hwblend = {"gl_hwblend", "1"};
+cvar_t		gl_hwblend = {"gl_hwblend", "0"};
 float		v_blend[4];		// rgba 0.0 - 1.0
 cvar_t		v_gamma = {"gl_gamma", "1.0"};
 cvar_t		v_contrast = {"gl_contrast", "1.0"};


### PR DESCRIPTION
when enabled cshifts are just happening twice