### PR TITLE
SKYBOX: Rotate 90 degrees to align with other engines

### DIFF
--- a/src/glsl/draw_world.vertex.glsl
+++ b/src/glsl/draw_world.vertex.glsl
@@ -66,7 +66,7 @@ void main()
 		TexCoordLightmap = vec3(0, 0, 0);
 		Direction = (position - cameraPosition);
 #if defined(DRAW_SKYBOX)
-		Direction = Direction.xzy;
+		Direction = vec3(-Direction.y, Direction.z, Direction.x);
 #endif
 #ifdef DRAW_DETAIL_TEXTURES
 		DetailCoord = vec2(0, 0);


### PR DESCRIPTION
Same fix as in 8a3dc977, but for modern renderer.

For #629