### PR TITLE
LINUX: add sys_highpriority cvar

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -20310,6 +20310,7 @@
     "sys_highpriority": {
       "default": "0",
       "group-id": "48",
+      "remarks": "Note: On linux setting a number higher than 1 also sets the priority number (1-95).",
       "type": "enum",
       "values": [
         {


### PR DESCRIPTION
LINUX: add sys_highpriority cvar for changing process priority.  Default to SCHED_RR with a priority of 1, all settings higher than 0 will use SCHED_FIFO with specified number as priority, bound to maximum SCHED_FIFO priority.  Low priority sets us back to the default scheduler with no priority.