### PR TITLE
INPUT: move macOS in_raw init to a point where in_raw cvar is actually registered

### DIFF
--- a/src/in_sdl2.c
+++ b/src/in_sdl2.c
@@ -560,16 +560,6 @@ void IN_Init (void)
 		Cmd_AddCommand("in_restart", IN_Restart_f);
 	}
 
-#ifdef __APPLE__
-	extern cvar_t in_raw;
-	if (in_raw.integer > 0) {
-		if (OSX_Mouse_Init() != 0) {
-			Com_Printf("warning: failed to initialize raw input mouse thread...\n");
-			Cvar_SetValue(&in_raw, 0);
-		}
-	}
-#endif
-
 	IN_StartupMouse ();
 	IN_StartupJoystick();
 }

--- a/src/vid_sdl2.c
+++ b/src/vid_sdl2.c
@@ -327,6 +327,13 @@ void IN_StartupMouse(void)
 	Cvar_Register(&in_ignore_touch_events);
 #ifdef __APPLE__
 	Cvar_Register(&in_ignore_deadkeys);
+
+	if (in_raw.integer > 0) {
+		if (OSX_Mouse_Init() != 0) {
+			Com_Printf("warning: failed to initialize raw input mouse thread...\n");
+			Cvar_SetValue(&in_raw, 0);
+		}
+	}
 #endif
 
 	mouseinitialized = true;


### PR DESCRIPTION
At the original code location the `in_raw` cvar looks like this:
```
(lldb) p in_raw
(cvar_t) $0 = {
  name = 0x00000001001dc3e0 "in_raw"
  string = 0x00000001001ba16c "1"
  flags = 4097
  OnChange = 0x0000000100140d1c (ezquake-darwin-arm`in_raw_callback at vid_sdl2.c:273)
  value = 0
  maxrulesetvalue = 0
  minrulesetvalue = 0
  defaultvalue = 0x0000000000000000
  latchedString = 0x0000000000000000
  autoString = 0x0000000000000000
  integer = 0
  color = ""
  modified = false
  teamplay = false
  group = NULL
  next_in_group = NULL
  hash_next = NULL
  next = NULL
}
```
Which will result in the init code not to be run, but reporting it was successfull.
