### PR TITLE
INSTALL: fix versioning for macOS bundle; simplify ad-hoc signing

### DIFF
--- a/misc/install/create_osx_bundle.sh
+++ b/misc/install/create_osx_bundle.sh
@@ -14,7 +14,7 @@ ARCH=$(uname -m | sed -e s/i.86/i386/ -e s/amd64/x86_64/ -e s/sun4u/sparc64/ -e 
 BUNDLE_NAME=ezQuake.app
 BINARY=ezquake-darwin-${ARCH}
 ICON_FILE=ezquake.icns
-VERSION=$(cat version.h | grep VERSION_NUMBER | cut -d " " -f 3 | sed -e 's/^"//' -e 's/"$//')
+VERSION=$(cat src/version.h | grep VERSION_NUMBER | cut -d " " -f 3 | sed -e 's/^"//' -e 's/"$//')
 
 if [ -d $BUNDLE_NAME ]; then
 	echo "$BUNDLE_NAME already exists"

--- a/misc/install/fixbundle.sh
+++ b/misc/install/fixbundle.sh
@@ -90,8 +90,6 @@ done
 function fix_symbols {
 	for DEP in $(get_deps "$1"); do
 		install_name_tool -change "$DEP" "@executable_path/../Frameworks/$(basename $(realpath $DEP))" "$1"
-		codesign --remove-signature "$1"
-		codesign -s - "$1"
 	done
 }
 
@@ -100,3 +98,5 @@ shopt -s nullglob
 for BINARY in "${@:2}" "$FRAMEWORK_DIR/"*.dylib "$FRAMEWORK_DIR/"*.so; do
 	fix_symbols "$BINARY"
 done
+
+codesign --force --deep --sign - $BUNDLE


### PR DESCRIPTION
Due to the source files being moved to a subdirectory the script failed to use a correct version when creating the bundle.

The ad-hoc signing could also be done a bit simpler..
