### PR TITLE
date/time hud element for the scoreboard

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -7099,7 +7099,7 @@
       "type": "string"
     },
     "hud_scoreclock_format": {
-      "desc": "Controls in what format the scoreclock is displayed.",
+      "desc": "Controls in what format the scoreclock is displayed. Check the link below for available options. You can also add text, e.g. \"time: %H:%M:%S\"",
       "remarks": "https://www.man7.org/linux/man-pages/man3/strftime.3.html",
       "group-id": "19",
       "type": "string"

--- a/help_variables.json
+++ b/help_variables.json
@@ -7088,6 +7088,71 @@
       "group-id": "19",
       "type": "integer"
     },
+    "hud_scoreclock_align_x": {
+      "desc": "Sets horizontal align of scoreclock.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_align_y": {
+      "desc": "Sets vertical align of scoreclock.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_format": {
+      "desc": "Controls in what format the scoreclock is displayed.",
+      "remarks": "https://www.man7.org/linux/man-pages/man3/strftime.3.html",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_frame": {
+      "desc": "Sets frame visibility and style for scoreclock.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_frame_color": {
+      "desc": "Defines the color of the background of the scoreclock HUD element. See HUD manual for more info.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_item_opacity": {
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_order": {
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
+      "group-id": "19",
+      "type": "integer"
+    },
+    "hud_scoreclock_place": {
+      "desc": "Sets relative positioning for scoreclock.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_pos_x": {
+      "desc": "Sets horizontal position of scoreclock.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_pos_y": {
+      "desc": "Sets vertical position of scoreclock.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_scale": {
+      "desc": "Scale of the scoreclock HUD element.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_show": {
+      "desc": "Toggles whether the scoreclock is displayed. It is only displayed when the scoreboard is open.",
+      "group-id": "19",
+      "type": "boolean"
+    },
+    "hud_scoreclock_proportional": {
+      "desc": "Toggles whether the scoreclock uses charset chars or TTF chars",
+      "group-id": "19",
+      "type": "boolean"
+    },
     "hud_digits_trim": {
       "desc": "Changes how large numbers are treated in Head Up Display.",
       "group-id": "19",

--- a/src/hud.c
+++ b/src/hud.c
@@ -1415,6 +1415,10 @@ void HUD_DrawObject(hud_t *hud)
 
 	hud->last_try_sequence = host_screenupdatecount;
 
+	if(hud->flags & HUD_NO_DRAW) {
+		return;
+	}
+
 	// Check if we should show this.
 	if (!HUD_ShouldShow(hud)) {
 		return;

--- a/src/hud_clock.c
+++ b/src/hud_clock.c
@@ -185,6 +185,42 @@ static void SCR_HUD_DrawDemoClock(hud_t *hud)
 	}
 }
 
+static void SCR_HUD_DrawScoreClock(hud_t *hud) {
+	int width, height;
+	int x, y;
+	static cvar_t
+			*hud_scoreclock_format = NULL,
+			*hud_scoreclock_scale = NULL,
+			*hud_scoreclock_proportional = NULL;
+
+	if (hud_scoreclock_format == NULL) {
+		hud_scoreclock_format = HUD_FindVar(hud, "format");
+		hud_scoreclock_scale = HUD_FindVar(hud, "scale");
+		hud_scoreclock_proportional = HUD_FindVar(hud, "proportional");
+	}
+
+	if(!hud_scoreclock_format->string)
+		return;
+
+	time_t t;
+	struct tm *ptm;
+	char datestr[256] = "bad date";
+	time(&t);
+	if ((ptm = localtime(&t)))
+		strftime(datestr, sizeof(datestr) - 1, hud_scoreclock_format->string, ptm);
+
+	width = Draw_StringLengthColors(datestr, -1, hud_scoreclock_scale->value, hud_scoreclock_proportional->integer);
+	height = SCR_GetClockStringHeight(false, hud_scoreclock_scale->value);
+
+	if(!width)
+		return;
+
+	if (!HUD_PrepareDraw(hud, width, height, &x, &y))
+		return;
+
+	Draw_SString(x, y, datestr, hud_scoreclock_scale->value, hud_scoreclock_proportional->integer);
+}
+
 ///
 /// cl_screen.c clock module: to be merged
 ///
@@ -352,6 +388,16 @@ void Clock_HudInit(void)
 		"blink", "1",
 		"countdown", "0",
 		"offset", "0",
+		"proportional", "0",
+		NULL
+	);
+
+	HUD_Register(
+		"scoreclock", NULL, "Shows current date and time on the scoreboard",
+		HUD_NO_DRAW, ca_disconnected, 8, SCR_HUD_DrawScoreClock,
+		"0", "screen", "center", "bottom", "0", "-10", "0", "0 0 0", NULL,
+		"scale", "1",
+		"format", "%d-%m-%Y %H:%M:%S",
 		"proportional", "0",
 		NULL
 	);

--- a/src/sbar.c
+++ b/src/sbar.c
@@ -1768,6 +1768,12 @@ static void Sbar_DeathmatchOverlay(int start)
 	if (!scr_scoreboard_borderless.value) {
 		Draw_Fill(xofs - 1, y - 1, rank_width + 2, 1, 0); //Border - Bottom
 	}
+
+	static hud_t *scoreclock = NULL;
+	if(scoreclock == NULL) // first time
+		scoreclock = HUD_Find("scoreclock");
+	if(scoreclock->show)
+		scoreclock->draw_func(scoreclock);
 }
 
 static void Sbar_TeamOverlay(void)


### PR DESCRIPTION
adds #772 

in-game:
- added a new hud element, scoreclock
  - it is only displayed when the scoreboard is visible (either at the end of the game or when using `+showscores`/`+showteamscores`)
  - `hud_scoreclock_format` cvar controls the format of the clock according to [this](https://www.man7.org/linux/man-pages/man3/strftime.3.html)

in-code:
- hud elements are no longer drawn by `HUD_DrawObject` if they have the flag `HUD_NO_DRAW` set (it was not used earlier)

notes:
- I think the `HUD_ON_INTERMISSION` flag does not work
