### PR TITLE
fix z-fighting 

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -4608,7 +4608,19 @@
       "type": "float",
       "values": [
         {
-          "description": "Value in range 0-25.",
+          "description": "Value in range 0 to 2.",
+          "name": "*"
+        }
+      ]
+    },
+    "gl_brush_polygonoffset_factor": {
+      "default": "0.05",
+      "desc": "Set the factor for gl_brush_polygonoffset. Negative values offset the brushes towards the player.",
+      "group-id": "35",
+      "type": "float",
+      "values": [
+        {
+          "description": "Value in range -1 to 1.",
           "name": "*"
         }
       ]

--- a/src/gl_state.c
+++ b/src/gl_state.c
@@ -947,10 +947,10 @@ void R_CustomPolygonOffset(r_polygonoffset_t mode)
 	rendering_state_t* current = &opengl.rendering_state;
 
 	if (mode != current->polygonOffset.option) {
-		extern cvar_t gl_brush_polygonoffset;
+		extern cvar_t gl_brush_polygonoffset, gl_brush_polygonoffset_factor;
 
-		float factor = (mode == r_polygonoffset_standard ? 0.05 : 1);
-		float units = (mode == r_polygonoffset_standard ? -bound(0, gl_brush_polygonoffset.value, 2.0) : 1);
+		float factor = (mode == r_polygonoffset_standard ? bound(-1, gl_brush_polygonoffset_factor.value, 1) : 1);
+		float units = (mode == r_polygonoffset_standard ? bound(0, gl_brush_polygonoffset.value, 2) : 1);
 		qbool enabled = (mode == r_polygonoffset_standard || mode == r_polygonoffset_outlines) && units != 0;
 
 		if (enabled) {

--- a/src/r_rmain.c
+++ b/src/r_rmain.c
@@ -162,6 +162,7 @@ cvar_t r_farclip                           = {"r_farclip", "8192", CVAR_RULESET_
 cvar_t r_skyname                           = {"r_skyname", "", 0, OnChange_r_skyname};
 cvar_t gl_detail                           = {"gl_detail","0"};
 cvar_t gl_brush_polygonoffset              = {"gl_brush_polygonoffset", "2.0"}; // This is the one to adjust if you notice flicker on lift @ e1m1 for instance, for z-fighting
+cvar_t gl_brush_polygonoffset_factor       = {"gl_brush_polygonoffset_factor", "0.05"};
 cvar_t gl_caustics                         = {"gl_caustics", "0"}; // 1
 cvar_t gl_lumatextures                     = {"gl_lumatextures", "1"};
 cvar_t gl_subdivide_size                   = {"gl_subdivide_size", "64"};
@@ -690,6 +691,7 @@ void R_Init(void)
 	Cvar_Register(&gl_clear);
 	Cvar_Register(&gl_clearColor);
 	Cvar_Register(&gl_brush_polygonoffset);
+	Cvar_Register(&gl_brush_polygonoffset_factor);
 
 	Cvar_Register(&gl_nocolors);
 	Cvar_Register(&gl_finish);


### PR DESCRIPTION
[this commit](https://github.com/QW-Group/ezquake-source/commit/155e9d731d419701c1c813b3d5ddef78abedb0ec) broke the z-fighting fix by making the units offset negative to prevent buttons being pushed into walls. On my machine it seems that negative offsets are no different than 0, however a negative factor can offset a brush in the opposing direction. I made the factor customizable (`gl_brush_polygonoffset_factor`, range -1 to 1), so players are free to choose which way the brushes are offset.

tested in the same situation as #747 as well as on a [custom map](https://cdn.discordapp.com/attachments/672796268585680906/1103663973045391360/zfixtest.bsp) with doors like this facing all 4 directions