### PR TITLE
fix centerprint not appearing during finales (#675)

### DIFF
--- a/src/cl_screen.c
+++ b/src/cl_screen.c
@@ -752,6 +752,7 @@ static void SCR_DrawElements(void)
 				if (!scr_notifyalways.integer) {
 					Con_ClearNotify();
 				}
+				HUD_Draw();
 			}
 			else if (cl.intermission == 2) {
 				Sbar_FinaleOverlay();
@@ -759,10 +760,9 @@ static void SCR_DrawElements(void)
 				if (!scr_notifyalways.integer) {
 					Con_ClearNotify();
 				}
+				HUD_Draw();
 			}
-
-			if (cls.state == ca_active)
-			{
+			else if (cls.state == ca_active) {
 				SCR_DrawNet ();
 				SCR_DrawTurtle ();
 #ifdef EXPERIMENTAL_SHOW_ACCELERATION
@@ -783,46 +783,43 @@ static void SCR_DrawElements(void)
 					SCR_VoiceMeter();
 				}
 
-				if (!cl.intermission) 
+				if ((key_dest != key_menu) && (scr_showcrosshair.integer || (!sb_showscores && !sb_showteamscores)))
 				{
-					if ((key_dest != key_menu) && (scr_showcrosshair.integer || (!sb_showscores && !sb_showteamscores)))
-					{
-						Draw_Crosshair ();
-					}
-
-					// Do not show if +showscores
-					if (!sb_showscores && !sb_showteamscores)
-					{ 
-						SCR_Draw_TeamInfo();
-
-						SCR_Draw_ShowNick();
-
-						SCR_CenterString_Draw();
-						SCR_DrawSpeed();
-						SCR_DrawClocks();
-						SCR_DrawQTVBuffer();
-						SCR_DrawFPS();
-					}
-
-					// QW262
-					SCR_DrawHud();
-
-					if (cls.mvdplayback) {
-						MVD_Screen();
-					}
-
-					// VULT DISPLAY KILLS
-					VX_TrackerThink();
-
-					if (CL_MultiviewEnabled())
-						SCR_DrawMultiviewOverviewElements ();
-
-					Sbar_Draw();
-					HUD_Draw();
-					HUD_Editor_Draw();
-
-					DemoControls_Draw();
+					Draw_Crosshair ();
 				}
+
+				// Do not show if +showscores
+				if (!sb_showscores && !sb_showteamscores)
+				{
+					SCR_Draw_TeamInfo();
+
+					SCR_Draw_ShowNick();
+
+					SCR_CenterString_Draw();
+					SCR_DrawSpeed();
+					SCR_DrawClocks();
+					SCR_DrawQTVBuffer();
+					SCR_DrawFPS();
+				}
+
+				// QW262
+				SCR_DrawHud();
+
+				if (cls.mvdplayback) {
+					MVD_Screen();
+				}
+
+				// VULT DISPLAY KILLS
+				VX_TrackerThink();
+
+				if (CL_MultiviewEnabled())
+					SCR_DrawMultiviewOverviewElements ();
+
+				Sbar_Draw();
+				HUD_Draw();
+				HUD_Editor_Draw();
+
+				DemoControls_Draw();
 			}
 		}
 

--- a/src/hud_centerprint.c
+++ b/src/hud_centerprint.c
@@ -227,7 +227,7 @@ void CenterPrint_HudInit(void)
 {
 	HUD_Register(
 		"centerprint", NULL, "Shows alerts from server, countdowns etc.",
-		HUD_PLUSMINUS, ca_active, 0, SCR_HUD_DrawCenterPrint,
+		HUD_PLUSMINUS | HUD_ON_FINALE, ca_active, 0, SCR_HUD_DrawCenterPrint,
 		"0", "screen", "center", "center", "0", "0", "0", "0 0 0", NULL,
 		"scale", "1",
 		"proportional", "0",


### PR DESCRIPTION
fix #675 and the `HUD_ON_FINALE` `HUD_ON_INTERMISSION` and `HUD_ON_SCORES` flags