### PR TITLE
date/time hud element for the scoreboard 

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -7100,6 +7100,71 @@
       "group-id": "19",
       "type": "integer"
     },
+    "hud_scoreclock_align_x": {
+      "desc": "Sets horizontal align of scoreclock.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_align_y": {
+      "desc": "Sets vertical align of scoreclock.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_format": {
+      "desc": "Controls in what format the scoreclock is displayed. Check the link below for available options. You can also add text, e.g. \"time: %H:%M:%S\"",
+      "remarks": "https://www.man7.org/linux/man-pages/man3/strftime.3.html",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_frame": {
+      "desc": "Sets frame visibility and style for scoreclock.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_frame_color": {
+      "desc": "Defines the color of the background of the scoreclock HUD element. See HUD manual for more info.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_item_opacity": {
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_order": {
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
+      "group-id": "19",
+      "type": "integer"
+    },
+    "hud_scoreclock_place": {
+      "desc": "Sets relative positioning for scoreclock.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoreclock_pos_x": {
+      "desc": "Sets horizontal position of scoreclock.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_pos_y": {
+      "desc": "Sets vertical position of scoreclock.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_scale": {
+      "desc": "Scale of the scoreclock HUD element.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoreclock_show": {
+      "desc": "Toggles whether the scoreclock is displayed. It is only displayed when the scoreboard is open.",
+      "group-id": "19",
+      "type": "boolean"
+    },
+    "hud_scoreclock_proportional": {
+      "desc": "Toggles whether the scoreclock uses charset chars or TTF chars",
+      "group-id": "19",
+      "type": "boolean"
+    },
     "hud_digits_trim": {
       "desc": "Changes how large numbers are treated in Head Up Display.",
       "group-id": "19",

--- a/src/cl_screen.c
+++ b/src/cl_screen.c
@@ -752,6 +752,7 @@ static void SCR_DrawElements(void)
 				if (!scr_notifyalways.integer) {
 					Con_ClearNotify();
 				}
+				HUD_Draw();
 			}
 			else if (cl.intermission == 2) {
 				Sbar_FinaleOverlay();
@@ -759,10 +760,9 @@ static void SCR_DrawElements(void)
 				if (!scr_notifyalways.integer) {
 					Con_ClearNotify();
 				}
+				HUD_Draw();
 			}
-
-			if (cls.state == ca_active)
-			{
+			else if (cls.state == ca_active) {
 				SCR_DrawNet ();
 				SCR_DrawTurtle ();
 #ifdef EXPERIMENTAL_SHOW_ACCELERATION
@@ -783,46 +783,43 @@ static void SCR_DrawElements(void)
 					SCR_VoiceMeter();
 				}
 
-				if (!cl.intermission) 
+				if ((key_dest != key_menu) && (scr_showcrosshair.integer || (!sb_showscores && !sb_showteamscores)))
 				{
-					if ((key_dest != key_menu) && (scr_showcrosshair.integer || (!sb_showscores && !sb_showteamscores)))
-					{
-						Draw_Crosshair ();
-					}
-
-					// Do not show if +showscores
-					if (!sb_showscores && !sb_showteamscores)
-					{ 
-						SCR_Draw_TeamInfo();
-
-						SCR_Draw_ShowNick();
-
-						SCR_CenterString_Draw();
-						SCR_DrawSpeed();
-						SCR_DrawClocks();
-						SCR_DrawQTVBuffer();
-						SCR_DrawFPS();
-					}
-
-					// QW262
-					SCR_DrawHud();
-
-					if (cls.mvdplayback) {
-						MVD_Screen();
-					}
-
-					// VULT DISPLAY KILLS
-					VX_TrackerThink();
-
-					if (CL_MultiviewEnabled())
-						SCR_DrawMultiviewOverviewElements ();
-
-					Sbar_Draw();
-					HUD_Draw();
-					HUD_Editor_Draw();
-
-					DemoControls_Draw();
+					Draw_Crosshair ();
 				}
+
+				// Do not show if +showscores
+				if (!sb_showscores && !sb_showteamscores)
+				{
+					SCR_Draw_TeamInfo();
+
+					SCR_Draw_ShowNick();
+
+					SCR_CenterString_Draw();
+					SCR_DrawSpeed();
+					SCR_DrawClocks();
+					SCR_DrawQTVBuffer();
+					SCR_DrawFPS();
+				}
+
+				// QW262
+				SCR_DrawHud();
+
+				if (cls.mvdplayback) {
+					MVD_Screen();
+				}
+
+				// VULT DISPLAY KILLS
+				VX_TrackerThink();
+
+				if (CL_MultiviewEnabled())
+					SCR_DrawMultiviewOverviewElements ();
+
+				Sbar_Draw();
+				HUD_Draw();
+				HUD_Editor_Draw();
+
+				DemoControls_Draw();
 			}
 		}
 

--- a/src/hud.c
+++ b/src/hud.c
@@ -1425,19 +1425,35 @@ void HUD_DrawObject(hud_t *hud)
 		return;
 	}
 
-	if (cl.intermission == 1  &&  !(hud->flags & HUD_ON_INTERMISSION))
-	{
-		return;
-	}
 
-	if (cl.intermission == 2 && !(hud->flags & HUD_ON_FINALE))
-	{
-		return;
-	}
+	if(hud->flags & HUD_NO_DRAW) {
+		// draw only during specified events (e.g. HUD_ON_INTERMISSION)
+		qbool draw = false;
 
-	if ((sb_showscores || sb_showteamscores) && !(hud->flags & HUD_ON_SCORES))
-	{
-		return;
+		if (cl.intermission == 1 && (hud->flags & HUD_ON_INTERMISSION))
+			draw = true;
+
+		else if (cl.intermission == 2 && !(hud->flags & HUD_ON_FINALE))
+			draw = true;
+
+		else if ((sb_showscores || sb_showteamscores) && (hud->flags & HUD_ON_SCORES))
+			draw = true;
+
+		//else if (???????? && (hud->flags & HUD_ON_DIALOG))
+		//	draw = true;
+
+		if(!draw)
+			return;
+
+	} else {
+		if (cl.intermission == 1 && !(hud->flags & HUD_ON_INTERMISSION))
+			return;
+
+		if (cl.intermission == 2 && !(hud->flags & HUD_ON_FINALE))
+			return;
+
+		if ((sb_showscores || sb_showteamscores) && !(hud->flags & HUD_ON_SCORES))
+			return;
 	}
 
 	if (hud->place_hud)

--- a/src/hud.h
+++ b/src/hud.h
@@ -23,7 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define __hud_h__
 
 // flags
-#define HUD_NO_DRAW            (1 <<  0)  // don't draw this automatically
+#define HUD_NO_DRAW            (1 <<  0)  // draw only during specified events (e.g. elements with flags = HUD_NO_DRAW | HUD_ON_INTERMISSION
+                                          // will only draw during the intermission)
 #define HUD_NO_SHOW            (1 <<  1)  // doesn't support show/hide
 #define HUD_NO_POS_X           (1 <<  2)  // doesn't support x positioning
 #define HUD_NO_POS_Y           (1 <<  3)  // doesn't support y positioning

--- a/src/hud_centerprint.c
+++ b/src/hud_centerprint.c
@@ -227,7 +227,7 @@ void CenterPrint_HudInit(void)
 {
 	HUD_Register(
 		"centerprint", NULL, "Shows alerts from server, countdowns etc.",
-		HUD_PLUSMINUS, ca_active, 0, SCR_HUD_DrawCenterPrint,
+		HUD_PLUSMINUS | HUD_ON_FINALE, ca_active, 0, SCR_HUD_DrawCenterPrint,
 		"0", "screen", "center", "center", "0", "0", "0", "0 0 0", NULL,
 		"scale", "1",
 		"proportional", "0",

--- a/src/hud_clock.c
+++ b/src/hud_clock.c
@@ -185,6 +185,42 @@ static void SCR_HUD_DrawDemoClock(hud_t *hud)
 	}
 }
 
+static void SCR_HUD_DrawScoreClock(hud_t *hud) {
+	int width, height;
+	int x, y;
+	static cvar_t
+			*hud_scoreclock_format = NULL,
+			*hud_scoreclock_scale = NULL,
+			*hud_scoreclock_proportional = NULL;
+
+	if (hud_scoreclock_format == NULL) {
+		hud_scoreclock_format = HUD_FindVar(hud, "format");
+		hud_scoreclock_scale = HUD_FindVar(hud, "scale");
+		hud_scoreclock_proportional = HUD_FindVar(hud, "proportional");
+	}
+
+	if(!hud_scoreclock_format->string)
+		return;
+
+	time_t t;
+	struct tm *ptm;
+	char datestr[256] = "bad date";
+	time(&t);
+	if ((ptm = localtime(&t)))
+		strftime(datestr, sizeof(datestr) - 1, hud_scoreclock_format->string, ptm);
+
+	width = Draw_StringLengthColors(datestr, -1, hud_scoreclock_scale->value, hud_scoreclock_proportional->integer);
+	height = SCR_GetClockStringHeight(false, hud_scoreclock_scale->value);
+
+	if(!width)
+		return;
+
+	if (!HUD_PrepareDraw(hud, width, height, &x, &y))
+		return;
+
+	Draw_SString(x, y, datestr, hud_scoreclock_scale->value, hud_scoreclock_proportional->integer);
+}
+
 ///
 /// cl_screen.c clock module: to be merged
 ///
@@ -354,6 +390,17 @@ void Clock_HudInit(void)
 		"offset", "0",
 		"proportional", "0",
 		NULL
+	);
+
+	// init scoreclock
+	HUD_Register(
+			"scoreclock", NULL, "Shows current date and time on the scoreboard",
+			HUD_NO_DRAW | HUD_ON_INTERMISSION | HUD_ON_SCORES | HUD_ON_FINALE, ca_disconnected, 8, SCR_HUD_DrawScoreClock,
+			"0", "screen", "center", "bottom", "0", "-10", "0", "0 0 0", NULL,
+			"scale", "1",
+			"format", "%d-%m-%Y %H:%M:%S",
+			"proportional", "0",
+			NULL
 	);
 }
 


### PR DESCRIPTION
adds https://github.com/QW-Group/ezquake-source/issues/772 and functionality for `HUD_NO_DRAW` 
<br>
 
### ! depends on https://github.com/QW-Group/ezquake-source/pull/778 !
<br>

in-game:

- added a new hud element, scoreclock

  - it is only displayed when the scoreboard is visible (either at the end of the game or when using `+showscores`/`+showteamscores`)

  - `hud_scoreclock_format` cvar controls the format of the clock according to [this](https://www.man7.org/linux/man-pages/man3/strftime.3.html)

<br>

in-code:  

- elements with the `HUD_NO_DRAW` flag set don't draw by default (e.g. an element with `flags = HUD_NO_DRAW | HUD_ON_INTERMISSION` will ONLY draw during the intermission)
