### PR TITLE
DOWNLOAD: bump download speed for client and server

### DIFF
--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -121,7 +121,7 @@ cvar_t	cl_pext_256packetentities = {"cl_pext_256packetentities", "1"};
 #endif
 #ifdef FTE_PEXT_CHUNKEDDOWNLOADS
 cvar_t  cl_pext_chunkeddownloads  = {"cl_pext_chunkeddownloads", "1"};
-cvar_t  cl_chunksperframe  = {"cl_chunksperframe", "5"};
+cvar_t  cl_chunksperframe  = {"cl_chunksperframe", "30"};
 #endif
 
 #ifdef FTE_PEXT_FLOATCOORDS

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -846,7 +846,7 @@ void CL_SendChunkDownloadReq(void)
 	extern cvar_t cl_chunksperframe;
 	int i, j, chunks;
 	
-	chunks = bound(1, cl_chunksperframe.integer, 5);
+	chunks = bound(1, cl_chunksperframe.integer, 30);
 
 	for (j = 0; j < chunks; j++)
 	{

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -42,7 +42,7 @@ cvar_t	sv_kickuserinfospamcount = {"sv_kickuserinfospamcount", "300"};
 cvar_t	sv_maxuploadsize = {"sv_maxuploadsize", "1048576"};
 
 #ifdef FTE_PEXT_CHUNKEDDOWNLOADS
-cvar_t  sv_downloadchunksperframe = {"sv_downloadchunksperframe", "2"};
+cvar_t  sv_downloadchunksperframe = {"sv_downloadchunksperframe", "15"};
 #endif
 
 #ifdef FTE_PEXT2_VOICECHAT
@@ -1104,6 +1104,7 @@ void SV_NextChunkedDownload(int chunknum, int percent, int chunked_download_numb
 #define CHUNKSIZE 1024
 	char buffer[CHUNKSIZE];
 	int i;
+	int maxchunks = bound(1, (int)sv_downloadchunksperframe.value, 30);
 
 	sv_client->file_percent = bound(0, percent, 100); //bliP: file percent
 
@@ -1113,13 +1114,9 @@ void SV_NextChunkedDownload(int chunknum, int percent, int chunked_download_numb
 		return;
 	}
 
-	if (sv_client->download_chunks_perframe)
-	{
-		int maxchunks = bound(1, (int)sv_downloadchunksperframe.value, 4);
-		// too much requests or client sent something wrong
-		if (sv_client->download_chunks_perframe >= maxchunks || chunked_download_number < 1)
-			return;
-	}
+	// Check if too much requests or client sent something wrong
+	if (sv_client->download_chunks_perframe >= maxchunks || chunked_download_number < 1)
+		return;
 
 	if (!sv_client->download_chunks_perframe) // ignore "rate" if not first packet per frame
 		if (sv_client->datagram.cursize + CHUNKSIZE+5+50 > sv_client->datagram.maxsize)


### PR DESCRIPTION
sv_downloadchunksperframe is 15 now, could be set up to 30.

cl_chunksperframe is 30 now, server could limit it by sv_downloadchunksperframe.

theoretical download speed is about 1024 * 30 * 77, 1024 is chunk size in bytes, 30 is chunks per frame, and 77 is frames per second.