### PR TITLE
LIGHTMAPS: Support for DECOUPLEDLM. 

### DIFF
--- a/src/bspfile.h
+++ b/src/bspfile.h
@@ -289,4 +289,11 @@ typedef struct {
 	byte           ambient_level[NUM_AMBIENTS];
 } dleaf_bsp2_t;
 
+typedef struct {
+	unsigned short lmwidth;
+	unsigned short lmheight;
+	int            lightofs;
+	float          vecs[2][4];
+} dlminfo_t;
+
 #endif /* !__BSPFILE_H__ */

--- a/src/gl_model.h
+++ b/src/gl_model.h
@@ -194,6 +194,8 @@ typedef struct msurface_s {
 	short               texturemins[2];
 	short               extents[2];
 
+	short               lmshift;
+
 	// gl lightmap coordinates
 	int                 light_s;
 	int                 light_t;
@@ -641,5 +643,8 @@ extern mplane_t frustum[4];
 
 // sky
 #define BACKFACE_EPSILON	0.01
+
+
+#define DEFAULT_LMSHIFT     4
 
 #endif	// __MODEL__

--- a/src/gl_model.h
+++ b/src/gl_model.h
@@ -206,7 +206,11 @@ typedef struct msurface_s {
 	struct	msurface_s  *drawflatchain;
 
 	mtexinfo_t          *texinfo;
-	
+
+	// decoupled lm
+	float               lmvecs[2][4];
+	float               lmvlen[2];
+
 	// lighting info
 	int                 dlightframe;
 	int                 dlightbits;

--- a/src/glm_brushmodel.c
+++ b/src/glm_brushmodel.c
@@ -34,8 +34,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 typedef struct vbo_world_surface_s {
 	float normal[4];
-	float tex_vecs0[4];
-	float tex_vecs1[4];
+	float lm_vecs0[4];
+	float lm_vecs1[4];
 } vbo_world_surface_t;
 
 void GLM_CreateBrushModelVAO(void)
@@ -70,8 +70,8 @@ void GLM_CreateBrushModelVAO(void)
 
 			VectorCopy(surf->plane->normal, surfaces[i].normal);
 			surfaces[i].normal[3] = surf->plane->dist;
-			memcpy(surfaces[i].tex_vecs0, surf->texinfo->vecs[0], sizeof(surf->texinfo->vecs[0]));
-			memcpy(surfaces[i].tex_vecs1, surf->texinfo->vecs[1], sizeof(surf->texinfo->vecs[1]));
+			memcpy(surfaces[i].lm_vecs0, surf->lmvecs[0], sizeof(surf->lmvecs[0]));
+			memcpy(surfaces[i].lm_vecs1, surf->lmvecs[1], sizeof(surf->lmvecs[1]));
 		}
 		buffers.Create(r_buffer_brushmodel_surface_data, buffertype_storage, "brushmodel-surfs", cl.worldmodel->numsurfaces * sizeof(vbo_world_surface_t), surfaces, bufferusage_constant_data);
 		Q_free(surfaces);

--- a/src/glsl/lighting.compute.glsl
+++ b/src/glsl/lighting.compute.glsl
@@ -45,6 +45,12 @@ void main()
 			vec3 PlaneMins0 = surfaces[surfaceNumber].vecs0;
 			vec3 PlaneMins1 = surfaces[surfaceNumber].vecs1;
 
+			float vlen0 = length(PlaneMins0);
+			vlen0 = vlen0 > 0.0f ? 1.0f / vlen0 : 0;
+
+			float vlen1 = length(PlaneMins1);
+			vlen1 = vlen1 > 0.0f ? 1.0f / vlen1 : 0;
+
 			// Build static lights: default to black
 			vec4 baseLightmap = vec4(0, 0, 0, 0);
 			if (mapIndexes.a < 64) {
@@ -76,8 +82,8 @@ void main()
 					vec3 impact = lightPositions[i].xyz - Plane.xyz * dist;
 					vec2 local = vec2(dot(impact, PlaneMins0), dot(impact, PlaneMins1));
 
-					int sd = int(abs(local[0] - sdelta)); // sdelta = s * 16 - tex->vecs[0][3] + surf->texturemins[0];
-					int td = int(abs(local[1] - tdelta)); // tdelta = t * 16 - tex->vecs[1][3] + surf->texturemins[1];
+					int sd = int(abs(local[0] - sdelta) * vlen0); // sdelta = s * (1 << surf->lmshift) + surf->texturemins[0] - surf->lmvecs[0][3];
+					int td = int(abs(local[1] - tdelta) * vlen1); // tdelta = t * (1 << surf->lmshift) + surf->texturemins[1] - surf->lmvecs[1][3];
 
 					if (sd > td) {
 						dist = sd + (td >> 1);

--- a/src/glsl/lighting_copy.compute.glsl
+++ b/src/glsl/lighting_copy.compute.glsl
@@ -33,6 +33,12 @@ void main()
 	vec3 PlaneMins0 = surfaces[surfaceNumber].vecs0;
 	vec3 PlaneMins1 = surfaces[surfaceNumber].vecs1;
 
+	float vlen0 = length(PlaneMins0);
+	vlen0 = vlen0 > 0.0f ? 1.0f / vlen0 : 0;
+
+	float vlen1 = length(PlaneMins1);
+	vlen1 = vlen1 > 0.0f ? 1.0f / vlen1 : 0;
+
 	// lightsActive
 	for (i = 0; i < lightsActive; ++i) {
 		float dist = dot(lightPositions[i].xyz, Plane.xyz) - Plane.a;
@@ -48,8 +54,8 @@ void main()
 		vec3 impact = lightPositions[i].xyz - Plane.xyz * dist;
 		vec2 local = vec2(dot(impact, PlaneMins0), dot(impact, PlaneMins1));
 
-		int sd = int(abs(local[0] - sdelta)); // sdelta = s * 16 - tex->vecs[0][3] + surf->texturemins[0];
-		int td = int(abs(local[1] - tdelta)); // tdelta = t * 16 - tex->vecs[1][3] + surf->texturemins[1];
+		int sd = int(abs(local[0] - sdelta) * vlen0); // sdelta = s * (1 << surf->lmshift) + surf->texturemins[0] - surf->lmvecs[0][3];
+		int td = int(abs(local[1] - tdelta) * vlen1); // tdelta = t * (1 << surf->lmshift) + surf->texturemins[1] - surf->lmvecs[1][3];
 
 		if (sd > td) {
 			dist = sd + (td >> 1);

--- a/src/r_brushmodel_load.c
+++ b/src/r_brushmodel_load.c
@@ -1063,6 +1063,7 @@ static void Mod_LoadFaces(model_t* loadmodel, lump_t* l, byte* mod_base)
 		}
 		out->plane = loadmodel->planes + planenum;
 		out->texinfo = loadmodel->texinfo + texinfo;
+		out->lmshift = DEFAULT_LMSHIFT;
 
 		CalcSurfaceExtents(loadmodel, out);
 
@@ -1107,6 +1108,7 @@ static void Mod_LoadFacesBSP2(model_t* loadmodel, lump_t* l, byte* mod_base)
 
 		out->plane = loadmodel->planes + planenum;
 		out->texinfo = loadmodel->texinfo + LittleLong(in->texinfo);
+		out->lmshift = DEFAULT_LMSHIFT;
 
 		CalcSurfaceExtents(loadmodel, out);
 

--- a/src/r_lightmaps.c
+++ b/src/r_lightmaps.c
@@ -80,8 +80,8 @@ static void R_BuildDlightList (msurface_t *surf)
 
 	numdlights = 0;
 
-	smax = (surf->extents[0]>>4)+1;
-	tmax = (surf->extents[1]>>4)+1;
+	smax = (surf->extents[0] >> surf->lmshift) + 1;
+	tmax = (surf->extents[1] >> surf->lmshift) + 1;
 	tex = surf->texinfo;
 	dlightbits = surf->dlightbits;
 
@@ -110,7 +110,7 @@ static void R_BuildDlightList (msurface_t *surf)
 
 		// check if this dlight will touch the surface
 		if (local[1] > 0) {
-			tdmin = local[1] - (tmax << 4);
+			tdmin = local[1] - (tmax << surf->lmshift);
 			if (tdmin < 0) {
 				tdmin = 0;
 			}
@@ -120,7 +120,7 @@ static void R_BuildDlightList (msurface_t *surf)
 		}
 
 		if (local[0] > 0) {
-			sdmin = local[0] - (smax << 4);
+			sdmin = local[0] - (smax << surf->lmshift);
 			if (sdmin < 0)
 				sdmin = 0;
 		} else {
@@ -166,19 +166,19 @@ static void R_AddDynamicLights(msurface_t *surf)
 	dlightinfo_t *light;
 	unsigned *dest;
 
-	smax = (surf->extents[0] >> 4) + 1;
-	tmax = (surf->extents[1] >> 4) + 1;
+	smax = (surf->extents[0] >> surf->lmshift) + 1;
+	tmax = (surf->extents[1] >> surf->lmshift) + 1;
 
 	for (i = 0, light = dlightlist; i < numdlights; i++, light++) {
 		irad = light->rad;
 		iminlight = light->minlight;
 
-		for (t = 0, _td = light->local[1]; t < tmax; t++, _td -= 16) {
+		for (t = 0, _td = light->local[1]; t < tmax; t++, _td -= (1 << surf->lmshift)) {
 			td = _td < 0 ? -_td : _td;
 
 			if (td < irad) {
 				dest = blocklights + t * smax * 3;
-				for (s = 0, _sd = light->local[0]; s < smax; s++, _sd -= 16, dest += 3) {
+				for (s = 0, _sd = light->local[0]; s < smax; s++, _sd -= (1 << surf->lmshift), dest += 3) {
 					sd = _sd < 0 ? -_sd : _sd;
 
 					if (sd + td < iminlight) {
@@ -221,8 +221,8 @@ static void R_BuildLightMap(msurface_t *surf, byte *dest, int stride)
 
 	surf->cached_dlight = !!numdlights;
 
-	smax = (surf->extents[0] >> 4) + 1;
-	tmax = (surf->extents[1] >> 4) + 1;
+	smax = (surf->extents[0] >> surf->lmshift) + 1;
+	tmax = (surf->extents[1] >> surf->lmshift) + 1;
 	size = smax * tmax;
 	blocksize = size * 3;
 	lightmap = surf->samples;
@@ -383,8 +383,8 @@ void R_RenderDynamicLightmaps(msurface_t *fa, qbool world)
 		}
 		theRect->l = fa->light_s;
 	}
-	smax = (fa->extents[0] >> 4) + 1;
-	tmax = (fa->extents[1] >> 4) + 1;
+	smax = (fa->extents[0] >> fa->lmshift) + 1;
+	tmax = (fa->extents[1] >> fa->lmshift) + 1;
 	if (theRect->w + theRect->l < fa->light_s + smax) {
 		theRect->w = fa->light_s - theRect->l + smax;
 	}
@@ -658,15 +658,15 @@ static void R_BuildSurfaceDisplayList(model_t* currentmodel, msurface_t *fa)
 		else {
 			s = DotProduct(vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3];
 			s -= fa->texturemins[0];
-			s += fa->light_s * 16;
-			s += 8;
-			s /= LIGHTMAP_WIDTH * 16; //fa->texinfo->texture->width;
+			s += fa->light_s * (1 << fa->lmshift);
+            s += (1 << fa->lmshift) * 0.5;
+			s /= LIGHTMAP_WIDTH * (1 << fa->lmshift);
 
 			t = DotProduct(vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3];
 			t -= fa->texturemins[1];
-			t += fa->light_t * 16;
-			t += 8;
-			t /= LIGHTMAP_HEIGHT * 16; //fa->texinfo->texture->height;
+			t += fa->light_t * (1 << fa->lmshift);
+			t += (1 << fa->lmshift) * 0.5;
+			t /= LIGHTMAP_HEIGHT * (1 << fa->lmshift);
 
 			poly->verts[i][5] = s;
 			poly->verts[i][6] = t;
@@ -692,8 +692,8 @@ static void R_BuildLightmapData(msurface_t* surf, int surfnum)
 {
 	lightmap_data_t* lm = &lightmaps[surf->lightmaptexturenum];
 	byte* lightmap = surf->samples;
-	unsigned int smax = (surf->extents[0] >> 4) + 1;
-	unsigned int tmax = (surf->extents[1] >> 4) + 1;
+	unsigned int smax = (surf->extents[0] >> surf->lmshift) + 1;
+	unsigned int tmax = (surf->extents[1] >> surf->lmshift) + 1;
 	unsigned int lightmap_flags;
 	int s, t, maps;
 
@@ -710,8 +710,8 @@ static void R_BuildLightmapData(msurface_t* surf, int surfnum)
 
 		for (s = 0; s < smax; ++s, data += 4, source += 4) {
 			data[0] = surfnum;
-			data[1] = (s * 16 + surf->texturemins[0] - surf->texinfo->vecs[0][3]);
-			data[2] = (t * 16 + surf->texturemins[1] - surf->texinfo->vecs[1][3]);
+			data[1] = (s * (1 << surf->lmshift) + surf->texturemins[0] - surf->texinfo->vecs[0][3]);
+			data[2] = (t * (1 << surf->lmshift) + surf->texturemins[1] - surf->texinfo->vecs[1][3]);
 			data[3] = 0;
 
 			source[0] = source[1] = source[2] = 0;
@@ -735,8 +735,8 @@ static void R_LightmapCreateForSurface(msurface_t *surf, int surfnum)
 	int smax, tmax;
 	byte *base;
 
-	smax = (surf->extents[0] >> 4) + 1;
-	tmax = (surf->extents[1] >> 4) + 1;
+	smax = (surf->extents[0] >> surf->lmshift) + 1;
+	tmax = (surf->extents[1] >> surf->lmshift) + 1;
 
 	if (smax > LIGHTMAP_WIDTH) {
 		Host_Error("%s: smax = %d > BLOCK_WIDTH", __func__, smax);
@@ -762,16 +762,16 @@ static int R_LightmapSurfaceSortFunction(const void* lhs_, const void* rhs_)
 	const msurface_t* rhs = *(const msurface_t**)rhs_;
 
 	if (r_lightmap_packbytexture.integer == 1) {
-		int lhs_size = ((lhs->extents[0] >> 4) + 1) * ((lhs->extents[1] >> 4) + 1);
-		int rhs_size = ((rhs->extents[0] >> 4) + 1) * ((rhs->extents[1] >> 4) + 1);
+		int lhs_size = ((lhs->extents[0] >> lhs->lmshift) + 1) * ((lhs->extents[1] >> lhs->lmshift) + 1);
+		int rhs_size = ((rhs->extents[0] >> rhs->lmshift) + 1) * ((rhs->extents[1] >> rhs->lmshift) + 1);
 
 		return rhs_size - lhs_size;
 	}
 	else if (r_lightmap_packbytexture.integer == 2) {
-		int lhs_width = ((lhs->extents[0] >> 4) + 1);
-		int lhs_height = ((lhs->extents[1] >> 4) + 1);
-		int rhs_width = ((rhs->extents[0] >> 4) + 1);
-		int rhs_height = ((rhs->extents[1] >> 4) + 1);
+		int lhs_width = ((lhs->extents[0] >> lhs->lmshift) + 1);
+		int lhs_height = ((lhs->extents[1] >> lhs->lmshift) + 1);
+		int rhs_width = ((rhs->extents[0] >> rhs->lmshift) + 1);
+		int rhs_height = ((rhs->extents[1] >> rhs->lmshift) + 1);
 
 		int height_diff = rhs_height - lhs_height;
 		int width_diff = rhs_width - lhs_width;

--- a/src/r_lightmaps_internal.h
+++ b/src/r_lightmaps_internal.h
@@ -6,7 +6,7 @@
 #define	LIGHTMAP_WIDTH  128
 #define	LIGHTMAP_HEIGHT 128
 
-#define MAX_LIGHTMAP_SIZE (32 * 32) // it was 4096 for quite long time
+#define MAX_LIGHTMAP_SIZE (64 * 64)
 #define LIGHTMAP_ARRAY_GROWTH 4
 
 typedef struct glRect_s {


### PR DESCRIPTION
This BSPX blob allows mappers to decouple lightmaps from textures so that a map can have higher lightmap resolution without scaling textures, something that otherwise risks introducing aliasing artifacts. Another quirk with texture scaling and vanilla lightmaps is that a texture with 0.5 scale next to one with 1.0 scale causes a visual glitch as the lightmap for the two surfaces have differing resolution.

The feature has been supported by ericw light compiler since end of 2022, and is enabled by setting `_world_units_per_luxel` to an integer value. A setting of `16` is close to vanilla resolution, and a lower value increases the lightmap resolution to the cost of increased bsp size. To reduce size the redundant vanilla lightmaps can be omitted with the `-novanilla` flag to the light compiler.