### PR TITLE
BUILD: move txt2c x64 debug target to v143 tools like the others

### DIFF
--- a/misc/vstudio/txt2c/txt2c.vcxproj
+++ b/misc/vstudio/txt2c/txt2c.vcxproj
@@ -41,7 +41,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">


### PR DESCRIPTION
I found the x64 debug target for subproject txt2c was the only target still using VS 2019 Platform tools (v142) instead of v143.
Didn't have 142 anymore and couldn't run that debug build... until now.