### PR TITLE
fixing and tweaking bindedit and aliasedit

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -695,6 +695,7 @@ void Cmd_EditAlias_f (void)
 	strlcat(final_string, s, sizeof(final_string));
 	strlcat(final_string, "\"", sizeof(final_string));
 	Key_ClearTyping();
+	key_linepos = 9 + (int)strlen(Cmd_Argv(1)) + 3; // move to where the commands are in the bind
 	memcpy(key_lines[edit_line]+1, str2wcs(final_string), (strlen(final_string) + 1) * sizeof(wchar));
 }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -695,7 +695,7 @@ void Cmd_EditAlias_f (void)
 	strlcat(final_string, s, sizeof(final_string));
 	strlcat(final_string, "\"", sizeof(final_string));
 	Key_ClearTyping();
-	key_linepos = 9 + (int)strlen(Cmd_Argv(1)) + 3; // move to where the commands are in the bind
+	key_linepos = 9 + (int)strlen(Cmd_Argv(1)) + 3; // move to where the commands are in the alias
 	memcpy(key_lines[edit_line]+1, str2wcs(final_string), (strlen(final_string) + 1) * sizeof(wchar));
 }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -673,7 +673,7 @@ void Cmd_AliasList_f (void)
 	Com_Printf ("------------\n%i/%i aliases\n", m, count);
 }
 
-void Cmd_EditAlias_f (void)
+void Cmd_AliasEdit_f (void)
 {
 	cmd_alias_t	*a;
 	char *s, *v, final_string[MAXCMDLINE - 1];
@@ -2370,7 +2370,7 @@ void Cmd_Init (void)
 #endif
 	Cmd_AddCommand ("echo", Cmd_Echo_f);
 	Cmd_AddCommand ("aliaslist", Cmd_AliasList_f);
-	Cmd_AddCommand ("aliasedit", Cmd_EditAlias_f);
+	Cmd_AddCommand ("aliasedit", Cmd_AliasEdit_f);
 	Cmd_AddCommand ("alias", Cmd_Alias_f);
 	Cmd_AddCommand ("tempalias", Cmd_Alias_f);
 	Cmd_AddCommand ("viewalias", Cmd_Viewalias_f);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -695,7 +695,7 @@ void Cmd_AliasEdit_f (void)
 		return;
 	}
 
-	a = Cmd_FindAlias(Cmd_Argv(1));
+	a = Cmd_FindAlias(s);
 	v = (a ? a->value : "");
 
 	strlcpy(final_string, "/alias \"", sizeof(final_string));
@@ -704,7 +704,7 @@ void Cmd_AliasEdit_f (void)
 	strlcat(final_string, v, sizeof(final_string));
 	strlcat(final_string, "\"", sizeof(final_string));
 	Key_ClearTyping();
-	key_linepos = 9 + (int)strlen(Cmd_Argv(1)) + 3; // move to where the commands are in the alias
+	key_linepos = 9 + (int)strlen(s) + 3; // move to where the commands are in the alias
 	memcpy(key_lines[edit_line]+1, str2wcs(final_string), (strlen(final_string) + 1) * sizeof(wchar));
 }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -676,7 +676,7 @@ void Cmd_AliasList_f (void)
 void Cmd_EditAlias_f (void)
 {
 	cmd_alias_t	*a;
-	char *s, final_string[MAXCMDLINE - 1];
+	char *s, *v, final_string[MAXCMDLINE - 1];
 	int c;
 
 	c = Cmd_Argc();
@@ -686,13 +686,22 @@ void Cmd_EditAlias_f (void)
 		return;
 	}
 
+	s = Cmd_Argv(1);
+	if (s[0] == '\0') {
+		Com_Printf("Alias name must be specified\n");
+		return;
+	} else if(strlen(s) >= MAX_ALIAS_NAME) {
+		Com_Printf("Alias name is too long\n");
+		return;
+	}
+
 	a = Cmd_FindAlias(Cmd_Argv(1));
-	s = (a ? a->value : "");
+	v = (a ? a->value : "");
 
 	strlcpy(final_string, "/alias \"", sizeof(final_string));
-	strlcat(final_string, Cmd_Argv(1), sizeof(final_string));
-	strlcat(final_string, "\" \"", sizeof(final_string));
 	strlcat(final_string, s, sizeof(final_string));
+	strlcat(final_string, "\" \"", sizeof(final_string));
+	strlcat(final_string, v, sizeof(final_string));
 	strlcat(final_string, "\"", sizeof(final_string));
 	Key_ClearTyping();
 	key_linepos = 9 + (int)strlen(Cmd_Argv(1)) + 3; // move to where the commands are in the alias

--- a/src/keys.c
+++ b/src/keys.c
@@ -1805,6 +1805,7 @@ void Key_EditBind_f(void) {
 	strlcat(final_string, keybinding, sizeof(final_string));
 	strlcat(final_string, "\"", sizeof(final_string));
 	Key_ClearTyping();
+	key_linepos = 8 + (int)strlen(Cmd_Argv(1)) + 3; // move to where the commands are in the bind
 	memcpy(key_lines[edit_line] + 1, str2wcs(final_string), (strlen(final_string) + 1) * sizeof(wchar));
 }
 

--- a/src/keys.c
+++ b/src/keys.c
@@ -1782,7 +1782,7 @@ void Key_BindList_f (void) {
 	}
 }
 
-void Key_EditBind_f(void) {
+void Key_BindEdit_f(void) {
 	char *keybinding, final_string[MAXCMDLINE - 1];
 	int keynum, argc = Cmd_Argc();
 
@@ -1970,7 +1970,7 @@ void Key_Init (void) {
 	// register our functions
 	Cmd_AddCommand("bindlist",Key_BindList_f);
 	Cmd_AddCommand("bind",Key_Bind_f);
-	Cmd_AddCommand("bindedit",Key_EditBind_f);
+	Cmd_AddCommand("bindedit", Key_BindEdit_f);
 	Cmd_AddCommand("unbind",Key_Unbind_f);
 	Cmd_AddCommand("unbindall",Key_Unbindall_f);
 	Cvar_SetCurrentGroup(CVAR_GROUP_CONSOLE);

--- a/src/keys.c
+++ b/src/keys.c
@@ -1798,7 +1798,7 @@ void Key_EditBind_f(void) {
 		return;
 	}
 
-	keybinding = keybindings[keynum];
+	keybinding = keybindings[keynum] ? keybindings[keynum] : "";
 	strlcpy(final_string, "/bind \"", sizeof(final_string));
 	strlcat(final_string, Cmd_Argv(1), sizeof(final_string));
 	strlcat(final_string, "\" \"", sizeof(final_string));


### PR DESCRIPTION
fixed bindedit crashing when used with an unbound key
after using bindedit or aliasedit the cursor now moves to the beginning of the bind/alias value
some additional validity checks in aliasedit