### PR TITLE
fixing the horrendous nvidia bug with outlines

### DIFF
--- a/src/glm_rmain.c
+++ b/src/glm_rmain.c
@@ -79,7 +79,7 @@ static void GLM_DrawWorldOutlines(void)
 
 		renderer.TextureUnitBind(0, normals);
 
-		R_ProgramUniform1f(r_program_uniform_outline_depth_threshold, gl_outline_world_depth_threshold.value);
+		R_ProgramUniform1f(r_program_uniform_outline_depth_threshold, bound(1, gl_outline_world_depth_threshold.value, 16));
 		// R_ProgramUniform1f(r_program_uniform_outline_scale, gl_outline_scale_world.value);
 		R_ProgramUniform3f(r_program_uniform_outline_color,
                            (float)gl_outline_color_world.color[0] / 255.0f,

--- a/src/glsl/fx_world_geometry.fragment.glsl
+++ b/src/glsl/fx_world_geometry.fragment.glsl
@@ -11,6 +11,10 @@ uniform float outline_depth_threshold;
 in vec2 TextureCoord;
 out vec4 frag_colour;
 
+bool vec_nequ(vec3 a, vec3 b) {
+	return dot(a, b) < 0.997; // todo: make this customizable?
+}
+
 void main()
 {
 	ivec2 coords = ivec2(TextureCoord.x * r_width, TextureCoord.y * r_height);
@@ -21,16 +25,20 @@ void main()
 	vec4 down   = texelFetch(normal_texture, coords + ivec2(0, 1), 0);
 
 	bool ignore = center.a == left.a && center.a == right.a && center.a == up.a && center.a == down.a;
-	if(ignore)
-		discard;
+	if(ignore) {
+		frag_colour = vec4(0);
+		return;
+	}
 
-	if(center.a == 0)
-		discard;
+	if(center.a == 0) {
+		frag_colour = vec4(0);
+		return;
+	}
 
-	if ((left.a  != 0 && center.rgb != left.rgb ) ||
-		(right.a != 0 && center.rgb != right.rgb) ||
-		(up.a    != 0 && center.rgb != up.rgb   ) ||
-		(down.a  != 0 && center.rgb != down.rgb )
+	if ((left.a  != 0 && vec_nequ(center.rgb, left.rgb )) ||
+		(right.a != 0 && vec_nequ(center.rgb, right.rgb)) ||
+		(up.a    != 0 && vec_nequ(center.rgb, up.rgb   )) ||
+		(down.a  != 0 && vec_nequ(center.rgb, down.rgb ))
 	) {
 		frag_colour.rgb = outline_color;
 		frag_colour.a = 1;


### PR DESCRIPTION
turns out amd drivers and nvidia drivers have different float precision so on nvidia you cant compare vectors with `!=` :P
![ezquake002](https://github.com/QW-Group/ezquake-source/assets/60076189/1f9a3a11-e032-45b6-b365-a2aad6b43b70)
