### PR TITLE
UI: Add notice on outdated client.

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -485,6 +485,22 @@
         }
       ]
     },
+    "allow_update_check": {
+      "default": "1",
+      "desc": "Checks if the the client is outdated. If a new version is found, this will be presented above the in-game menu. The version check performs a HTTP request to GitHub once per launch without introducing any application start delay. Any error querying the latest version assumes the current client is the latest.",
+      "group-id": "2",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Deny update check.",
+          "name": "false"
+        },
+        {
+          "description": "Allow update check.",
+          "name": "true"
+        }
+      ]
+    },
     "auth_timeout": {
       "desc": "Not currently used.",
       "group-id": "43",

--- a/src/central.c
+++ b/src/central.c
@@ -694,14 +694,10 @@ void Central_Shutdown(void)
 		curl_multi_cleanup(curl_handle);
 		curl_handle = NULL;
 	}
-
-	curl_global_cleanup();
 }
 
 void Central_Init(void)
 {
-	curl_global_init(CURL_GLOBAL_DEFAULT);
-
 // TODO: client-only version
 #ifdef SERVER_ONLY
 	Cvar_Register(&sv_www_address);

--- a/src/host.c
+++ b/src/host.c
@@ -48,6 +48,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "EX_qtvlist.h"
 #include "r_renderer.h"
 #include "central.h"
+#include <curl/curl.h>
 
 double		curtime;
 
@@ -637,6 +638,9 @@ void Host_Init (int argc, char **argv, int default_memsize)
 	int i;
 	char *cfg_name;
 
+	// central, version check etc
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+
 	COM_InitArgv (argc, argv);
 	COM_StoreOriginalCmdline(argc, argv);
 
@@ -697,6 +701,7 @@ void Host_Init (int argc, char **argv, int default_memsize)
 	Sys_CvarInit();
 	CM_Init ();
 	Mod_Init ();
+	VersionCheck_Init();
 
 #ifndef CLIENTONLY
 	SV_Init ();
@@ -807,6 +812,10 @@ void Host_Shutdown (void)
 	FS_Shutdown();
 	SYSINFO_Shutdown();
 	Q_free(com_args_original);
+
+	VersionCheck_Shutdown();
+
+	curl_global_cleanup();
 }
 
 void Host_Quit (void)

--- a/src/menu_ingame.c
+++ b/src/menu_ingame.c
@@ -32,6 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "settings.h"
 #include "settings_page.h"
 #include "server.h"
+#include "version.h"
 
 #define TOPMARGIN (6*LETTERWIDTH)
 
@@ -169,8 +170,19 @@ static settings_page *M_Ingame_Current(void) {
 }
 
 void M_Ingame_Draw(void) {
+	char version[VERSION_MAX_LEN] = { 0 };
+	qbool outdated;
+
 	M_Unscale_Menu();
 	Settings_Draw(0, TOPMARGIN, vid.width, vid.height - TOPMARGIN, M_Ingame_Current());
+
+	outdated = VersionCheck_GetLatest(version);
+	if (outdated)
+	{
+		char message[4096] = { 0 };
+		snprintf(message, sizeof(message), "Outdated client %s, latest version is %s", VERSION_NUMBER, version);
+		UI_Print_Center(0, 32, vid.width, message, 0);
+	}
 }
 
 void M_Ingame_Key(int key) {

--- a/src/version.c
+++ b/src/version.c
@@ -29,6 +29,23 @@
 #include "common.h"
 #include "version.h"
 
+#include <jansson.h>
+#include <SDL_mutex.h>
+#include <SDL_thread.h>
+#include <curl/curl.h>
+
+
+#define VERSION_UNKNOWN "Unknown"
+#define VERSION_GITHUB_MAXLEN 32768 // ~2k @ ~2023
+#define VERSION_GITHUB_URL "https://api.github.com/repos/qw-group/ezquake-source/releases/latest"
+
+static char version_latest[VERSION_MAX_LEN] = VERSION_UNKNOWN;
+static qbool version_refreshing = false;
+static SDL_mutex *version_mutex = NULL;
+
+static void VersionCheck_OnConfigChange(cvar_t *var, char *string, qbool *cancel);
+static cvar_t allow_update_check  = {"allow_update_check",  "1", CVAR_NONE, VersionCheck_OnConfigChange};
+
 /*
 =======================
 CL_Version_f
@@ -129,4 +146,205 @@ char *VersionStringFull (void)
 	snprintf (str, sizeof(str), SERVER_NAME " %s " "(" QW_PLATFORM ")" "\n", VersionString());
 
 	return str;
+}
+
+typedef struct version_context_St
+{
+	char *buffer;
+	char *ptr;
+} version_context_t;
+
+static size_t VersionReadGitHubResponse(void* chunk, size_t size, size_t nmemb, void* user_data)
+{
+	version_context_t* ctx = (version_context_t *) user_data;
+
+	size_t chunk_len = size * nmemb;
+	size_t remaining = VERSION_GITHUB_MAXLEN - (ctx->ptr - ctx->buffer) - 1;
+
+	if (chunk_len > remaining)
+	{
+		return 0;
+	}
+
+	memcpy(ctx->ptr, chunk, chunk_len);
+	ctx->ptr += chunk_len;
+	*ctx->ptr = '\0';
+
+	return chunk_len;
+}
+
+static int VersionCheck_Thread(void *args)
+{
+	char buffer[VERSION_GITHUB_MAXLEN] = { 0 };
+	json_error_t error;
+	json_t *root, *tag_name;
+	struct curl_slist *headers = NULL;
+	version_context_t ctx = {
+		.buffer = buffer,
+		.ptr = buffer,
+	};
+
+	root = tag_name = NULL;
+
+	CURL* curl = curl_easy_init();
+	if (!curl)
+	{
+		Com_DPrintf("Unable to create cURL client\n");
+		goto cleanup;
+	}
+
+	curl_easy_setopt(curl, CURLOPT_URL, VERSION_GITHUB_URL);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, VersionReadGitHubResponse);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ctx);
+
+	headers = curl_slist_append(headers, "User-Agent: Shub-Niggurath Inc");
+	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+	
+	CURLcode res = curl_easy_perform(curl);
+	if (res != CURLE_OK)
+	{
+		Com_DPrintf("Could not fetch latest version: %s", curl_easy_strerror(res));
+		goto cleanup;
+	}
+
+	root = json_loads(buffer, 0, &error);
+	if (!root)
+	{
+		Com_DPrintf("JSON decode failed: %s", error.text);
+		goto cleanup;
+	}
+	
+	tag_name = json_object_get(root, "tag_name");
+	if (!json_is_string(tag_name))
+	{
+		Com_DPrintf("Version not found in GitHub response");
+		goto cleanup;
+	}
+
+	const char* version_str = json_string_value(tag_name);
+
+	SDL_LockMutex(version_mutex);
+	strlcpy(version_latest, version_str, VERSION_MAX_LEN);
+	SDL_UnlockMutex(version_mutex);
+
+cleanup:
+	if (root != NULL)
+		json_decref(root);
+	if (curl != NULL)
+		curl_easy_cleanup(curl);
+
+	SDL_LockMutex(version_mutex);
+	version_refreshing = false;
+	SDL_UnlockMutex(version_mutex);
+
+	return 0;
+}
+
+static void VersionCheck_Refresh(void)
+{
+	SDL_LockMutex(version_mutex);
+
+	if (!version_refreshing)
+	{
+		SDL_Thread *thread = SDL_CreateThread(VersionCheck_Thread, "Version fetcher", NULL);
+		if (!thread)
+		{
+			Com_DPrintf("Could not start version fetcher: %s\n", SDL_GetError());
+			version_refreshing = false;
+		}
+		else
+		{
+			SDL_DetachThread(thread);
+			version_refreshing = true;
+		}
+	}
+
+	SDL_UnlockMutex(version_mutex);
+}
+
+static void VersionCheck_OnConfigChange(cvar_t *cfg, char *string, qbool *cancel)
+{
+	if (strcmp(string, "0") == 0)
+	{
+		return;
+	}
+
+	VersionCheck_Refresh();
+}
+
+void VersionCheck_Init(void)
+{
+	Cvar_Register(&allow_update_check);
+
+	version_mutex = SDL_CreateMutex();
+}
+
+void VersionCheck_Shutdown(void)
+{
+	if (version_mutex != NULL)
+	{
+		SDL_DestroyMutex(version_mutex);
+		version_mutex = NULL;
+	}
+}
+
+typedef struct semantic_version_St
+{
+	int major;
+	int minor;
+	int patch;
+} semantic_version_t;
+
+static qbool SemanticVersionFromString(const char* value, semantic_version_t* version)
+{
+	if (!value)
+		return false;
+	if (sscanf(value, "%d.%d.%d", &version->major, &version->minor, &version->patch) != 3)
+		return false;
+	return true;
+}
+
+static qbool VersionCheck_CompareVersions(const semantic_version_t *this_version, const semantic_version_t *latest_version)
+{
+	if (this_version->major < latest_version->major)
+		return true;
+	if (this_version->major > latest_version->major)
+		return false;
+	if (this_version->minor < latest_version->minor)
+		return true;
+	if (this_version->minor > latest_version->minor)
+		return false;
+	return this_version->patch < latest_version->patch;
+}
+
+// Assumes any failures = already on latest version to avoid erroneous showing of update message
+static qbool VersionCheck_IsOutdated(const char recent_version[VERSION_MAX_LEN])
+{
+	semantic_version_t v1, v2;
+
+	if (strcmp(recent_version, VERSION_UNKNOWN) == 0)
+		return false;
+	
+	if (!SemanticVersionFromString(VERSION_NUMBER, &v1))
+	{
+		Com_DPrintf("Could not parse own version: %s", VERSION_NUMBER);
+		return false;
+	}
+
+	if (!SemanticVersionFromString(recent_version, &v2))
+	{
+		Com_DPrintf("Could not parse recent version: %s", recent_version);
+		return false;
+	}
+
+	return VersionCheck_CompareVersions(&v1, &v2);
+}
+
+qbool VersionCheck_GetLatest(char dest[VERSION_MAX_LEN])
+{
+	SDL_LockMutex(version_mutex);
+	strlcpy(dest, version_latest, VERSION_MAX_LEN);
+	SDL_UnlockMutex(version_mutex);
+
+	return VersionCheck_IsOutdated(dest);
 }

--- a/src/version.h
+++ b/src/version.h
@@ -79,11 +79,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // Note: for server mods to detect version, change VERSION_NUM below
 #define VERSION_NUMBER "3.6.4-dev"
+#define VERSION_MAX_LEN 32
 
 void CL_Version_f(void);
 char *VersionString(void);
 char *VersionStringColour(void);
 char *VersionStringFull(void);
+
+void VersionCheck_Init(void);
+void VersionCheck_Shutdown(void);
+qbool VersionCheck_GetLatest(char dest[VERSION_MAX_LEN]);
 
 #ifndef SERVERONLY
 #define SERVER_NAME         "EZQUAKE"


### PR DESCRIPTION
A first attempt at version notification. Will show a version outdated message above the in-game menu, which is probably one of the most seen views that doesn't obscure gameplay. Can be extended later on to interact with /version and /f_version.

Fixes #827