### PR TITLE
TEXTURES: Fix competitive issues with fence textures.

### DIFF
--- a/src/r_brushmodel_load.c
+++ b/src/r_brushmodel_load.c
@@ -1665,6 +1665,7 @@ void R_LoadBrushModelTextures(model_t *m)
 		noscale_flag = 0;
 		noscale_flag = (!gl_scaleModelTextures.value && !m->isworldmodel) ? TEX_NOSCALE : noscale_flag;
 		noscale_flag = (!gl_scaleTurbTextures.value  && Mod_IsTurbTextureName(m, tx->name)) ? TEX_NOSCALE : noscale_flag;
+		noscale_flag = (!gl_scaleAlphaTextures.value  && Mod_IsAlphaTextureName(m, tx->name)) ? TEX_NOSCALE : noscale_flag;
 
 		mipTexLevel  = noscale_flag ? 0 : gl_miptexLevel.value;
 

--- a/src/r_texture.h
+++ b/src/r_texture.h
@@ -129,7 +129,7 @@ void R_TextureSizeRoundUp(int orig_width, int orig_height, int* width, int* heig
 const char* R_TextureIdentifier(texture_ref ref);
 #endif
 
-extern cvar_t gl_max_size, gl_scaleModelTextures, gl_scaleTurbTextures, gl_scaleModelSimpleTextures, gl_miptexLevel, gl_scaleskytextures;
+extern cvar_t gl_max_size, gl_scaleModelTextures, gl_scaleTurbTextures, gl_scaleAlphaTextures, gl_scaleModelSimpleTextures, gl_miptexLevel, gl_scaleskytextures;
 extern cvar_t gl_no24bit;
 extern texture_ref underwatertexture, detailtexture, solidwhite_texture, solidblack_texture, transparent_texture;
 

--- a/src/r_texture_cvars.c
+++ b/src/r_texture_cvars.c
@@ -48,6 +48,7 @@ cvar_t gl_anisotropy = { "gl_anisotropy","16", 0, OnChange_gl_anisotropy };
 cvar_t gl_scaleModelTextures = { "gl_scaleModelTextures", "0", CVAR_RELOAD_GFX };
 cvar_t gl_scaleModelSimpleTextures = { "gl_scaleModelSimpleTextures", "0", CVAR_RELOAD_GFX };
 cvar_t gl_scaleTurbTextures = { "gl_scaleTurbTextures", "1", CVAR_RELOAD_GFX };
+cvar_t gl_scaleAlphaTextures = { "gl_scaleAlphaTextures", "0", CVAR_RELOAD_GFX };
 cvar_t gl_scaleskytextures = { "gl_scaleskytextures", "0", CVAR_RELOAD_GFX };
 cvar_t gl_no24bit = { "gl_no24bit", "0", CVAR_RELOAD_GFX };
 
@@ -181,6 +182,7 @@ void R_TextureRegisterCvars(void)
 		Cvar_Register(&gl_scaleModelSimpleTextures);
 		Cvar_Register(&gl_scaleTurbTextures);
 		Cvar_Register(&gl_scaleskytextures);
+		Cvar_Register(&gl_scaleAlphaTextures);
 		Cvar_Register(&gl_miptexLevel);
 		Cvar_Register(&gl_picmip);
 		Cvar_Register(&gl_lerpimages);


### PR DESCRIPTION
Aligns the various uglification settings to how gl_textureless deal with fence textures to avoid putting players with gl_miptexlevel > 0, gl_picmip > 0, gl_max_size < 8192 at a competitive disadvantage by keeping fence textures verbatim. Future improvements could be to actually average or pixelate the textures, while keeping the fence alpha intact, but this fixes the immeadiate issue.

Mostly fixes #789, no competitive penalty for the non-normal examples.