### PR TITLE
SDL: Default to no keyboard grab on Windows.

### DIFF
--- a/src/vid_sdl2.c
+++ b/src/vid_sdl2.c
@@ -191,7 +191,7 @@ cvar_t vid_minimize_on_focus_loss = {"vid_minimize_on_focus_loss", CVAR_DEF1, CV
 // TODO: Move the in_* cvars
 cvar_t in_raw                     = {"in_raw",                     "1",       CVAR_ARCHIVE | CVAR_SILENT, in_raw_callback};
 cvar_t in_grab_windowed_mouse     = {"in_grab_windowed_mouse",     "1",       CVAR_ARCHIVE | CVAR_SILENT, in_grab_windowed_mouse_callback};
-cvar_t vid_grab_keyboard          = {"vid_grab_keyboard",          CVAR_DEF2, CVAR_LATCH_GFX }; /* Needs vid_restart thus vid_.... */
+cvar_t vid_grab_keyboard          = {"vid_grab_keyboard",          "0",       CVAR_LATCH_GFX }; /* Needs vid_restart thus vid_.... */
 #ifdef EZ_MULTIPLE_RENDERERS
 cvar_t vid_renderer               = {"vid_renderer",               "1",       CVAR_LATCH_GFX };
 #endif


### PR DESCRIPTION
This is the default on Linux, and incidentally used to be the default on Windows as well, until vcpkg got introduced which brought a modern SDL version with support for keyboard grabbing.

Fixes #830