### PR TITLE
GFX: Fix fence textures on func.

### DIFF
--- a/src/glm_brushmodel.c
+++ b/src/glm_brushmodel.c
@@ -129,7 +129,6 @@ void GLM_ChainBrushModelSurfaces(model_t* clmodel, entity_t* ent)
 {
 	int i;
 	msurface_t* psurf;
-	extern msurface_t* alphachain;
 	qbool drawFlatFloors = r_drawflat_mode.integer == 0 && (r_drawflat.integer == 2 || r_drawflat.integer == 1) && clmodel->isworldmodel;
 	qbool drawFlatWalls = r_drawflat_mode.integer == 0 && (r_drawflat.integer == 3 || r_drawflat.integer == 1) && clmodel->isworldmodel;
 
@@ -158,10 +157,6 @@ void GLM_ChainBrushModelSurfaces(model_t* clmodel, entity_t* ent)
 
 			clmodel->first_texture_chained = min(clmodel->first_texture_chained, psurf->texinfo->miptex);
 			clmodel->last_texture_chained = max(clmodel->last_texture_chained, psurf->texinfo->miptex);
-		}
-		else if (psurf->flags & SURF_DRAWALPHA) {
-			// FIXME: Find an example...
-			CHAIN_SURF_B2F(psurf, alphachain); // FIXME: ?
 		}
 		else {
 			if (drawFlatFloors && (psurf->flags & SURF_DRAWFLAT_FLOOR)) {


### PR DESCRIPTION
This caused entities with fence textures to not render. Most likely a copy-paste error from glc as alphachain is otherwise not part of the modern renderer.

Fixes #757