### PR TITLE
CI: Double-zip macOS app to keep executable bit.

### DIFF
--- a/.github/workflows/build-targets.yml
+++ b/.github/workflows/build-targets.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: macos-arm64
-        path: artifact
+        path: ezQuake.zip
 
   macos-intel-build:
     if: github.repository == 'QW-Group/ezquake-source'
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: macos-intel
-        path: artifact
+        path: ezQuake.zip
 
   linux-build:
     if: github.repository == 'QW-Group/ezquake-source'

--- a/.github/workflows/scripts/homebrew.sh
+++ b/.github/workflows/scripts/homebrew.sh
@@ -61,8 +61,7 @@ function create_bundle() {
     echo "Bundled content types:"
     find ezQuake.app/Contents -type f -exec file {} \;
 
-    mkdir artifact
-    mv ezQuake.app artifact/
+    zip -9 ezQuake.zip ezQuake.app
 }
 
 function build_intel() {


### PR DESCRIPTION
More details in GitHub documentation:

https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files