### PR TITLE
CI: Run CI for downstream projects.

### DIFF
--- a/.github/workflows/build-targets.yml
+++ b/.github/workflows/build-targets.yml
@@ -1,8 +1,7 @@
 name: build targets
-on: [pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   windows-build:
-    if: github.repository == 'QW-Group/ezquake-source'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -48,7 +47,6 @@ jobs:
         path: .vs\${{ matrix.platform }}\${{ matrix.config }}\Output\ezQuake.exe
 
   macos-arm-build:
-    if: github.repository == 'QW-Group/ezquake-source'
     runs-on: macos-12
     steps:
     - name: Check out code
@@ -71,7 +69,6 @@ jobs:
         path: artifact
 
   macos-intel-build:
-    if: github.repository == 'QW-Group/ezquake-source'
     runs-on: macos-12
     steps:
     - name: Check out code
@@ -94,7 +91,6 @@ jobs:
         path: artifact
 
   linux-build:
-    if: github.repository == 'QW-Group/ezquake-source'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Limiting CI to only upstream project requires contributors to carry their own configuration for CI up until creating a PR, at which point that commit has to be dropped. As there's no drawback to always building, better just enable it everywhere.