### PR TITLE
Pipeline use docker for linux builds

### DIFF
--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -87,18 +87,21 @@ jobs:
        include:
          - target: linux-x86_64
            platform: x86_64
+    container:
+      image: debian:testing
+      options: --privileged
 
     steps:
+    - name: Install dependencies
+      run: apt-get -qy update && apt-get -qy install curl file libfuse2 git make sudo git
+
     - name: Check out code
       uses: actions/checkout@v3
       with:
         submodules: true
 
-    - name: Install dependencies
-      run: sudo apt-get install libfuse2 openssh-client
-
     - name: Build
-      run: ./misc/appimage/appimage-manual_creation.sh
+      run:  git config --global --add safe.directory $PWD && ./misc/appimage/appimage-manual_creation.sh
 
     - name: Create checksum
       run: |

--- a/.github/workflows/build-and-deploy-snapshots.yml
+++ b/.github/workflows/build-and-deploy-snapshots.yml
@@ -85,15 +85,21 @@ jobs:
        include:
          - target: linux-x86_64
            platform: x86_64
+    container:
+      image: debian:testing
+      options: --privileged
 
     steps:
+    - name: Install dependencies
+      run: apt-get -qy update && apt-get -qy install curl file libfuse2 git make sudo git ssh-client
+
     - name: Check out code
       uses: actions/checkout@v3
       with:
         submodules: true
 
-    - name: Install dependencies
-      run: sudo apt-get install libfuse2 openssh-client
+    - name: Build
+      run:  git config --global --add safe.directory $PWD && ./misc/appimage/appimage-manual_creation.sh
 
     - name: Build
       run: ./misc/appimage/appimage-manual_creation.sh

--- a/.github/workflows/build-targets.yml
+++ b/.github/workflows/build-targets.yml
@@ -47,7 +47,7 @@ jobs:
         path: .vs\${{ matrix.platform }}\${{ matrix.config }}\Output\ezQuake.exe
 
   macos-build:
-    runs-on: macos-14
+    runs-on: macos-13
     strategy:
       matrix:
         ARCH: ["arm64","intel"]

--- a/.github/workflows/build-targets.yml
+++ b/.github/workflows/build-targets.yml
@@ -80,18 +80,21 @@ jobs:
        include:
          - target: linux-x86_64
            platform: x86_64
+    container:
+      image: debian:testing
+      options: --privileged
 
     steps:
+    - name: Install dependencies
+      run: apt-get -qy update && apt-get -qy install curl file libfuse2 git make sudo git
+
     - name: Check out code
       uses: actions/checkout@v3
       with:
         submodules: true
 
-    - name: Install dependencies
-      run: sudo apt-get install libfuse2
-
     - name: Build
-      run: ./misc/appimage/appimage-manual_creation.sh
+      run:  git config --global --add safe.directory $PWD && ./misc/appimage/appimage-manual_creation.sh
 
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
    PIPELINE: linux - use docker to generate appimage so we can choose the distro/version, this is primarily so we can use a newer version of libsdl2 in which mice above 1khz work properly
