### PR TITLE
BUILD: appimage - append +qwurl %u to exec entry in desktop file

### DIFF
--- a/misc/appimage/appimage-manual_creation.sh
+++ b/misc/appimage/appimage-manual_creation.sh
@@ -37,7 +37,11 @@ int main(){
 
 QUAKE_SCRIPT='#!/usr/bin/env bash
 export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
-cd "$OWD"
+if [ ! -e "$OWD/id1" ];then
+	cd "$(dirname "$APPIMAGE")"
+else
+	cd "$OWD"
+fi
 "${APPDIR}/usr/bin/test"  >/dev/null 2>&1 |:
 FAIL=${PIPESTATUS[0]}
 if [ $FAIL -eq 0 ];then
@@ -49,11 +53,10 @@ else
 	"${APPDIR}/usr/lib-override/ld-linux-'$ARCHDASH'.so.2" "${APPDIR}/usr/bin/ezquake-linux-'$ARCH'" $*
 fi
 exitstatus=$?
-
 if [ $exitstatus -eq 0 ];then
 	#fix qwurl association if set for appimage
 	grep -q "^Exec=/tmp/.mount_" "${HOME}/.local/share/applications/qw-url-handler.desktop" && \
-		sed -i "s|^Exec=.*|Exec=${APPIMAGE}|g" "${HOME}/.local/share/applications/qw-url-handler.desktop"
+		sed -i "s|^Exec=.*|Exec=${APPIMAGE} +qwurl %u|g" "${HOME}/.local/share/applications/qw-url-handler.desktop"
 fi
 exit $exitstatus
 '


### PR DESCRIPTION
the uri should be passed in as first argument regardless but it would appear under some circumstances this doesn't happen