### PR TITLE
improvements to some numeric hud elements

### DIFF
--- a/src/hud_ammo.c
+++ b/src/hud_ammo.c
@@ -144,7 +144,7 @@ static void SCR_HUD_DrawAmmo(
 	// 'New HUD' used to just return - instead draw blank space so other objects can be placed
 	// If user has specified 'show_always', carry on and show current value of STAT_AMMO
 	if (!num && !always) {
-		if (style < 2) {
+		if (style < 2 || style == 3) {
 			// use this to calculate sizes, but draw_content is false
 			SCR_HUD_DrawNum2(hud, 0, false, scale, style, digits, s_align, proportional, false);
 		}
@@ -168,7 +168,7 @@ static void SCR_HUD_DrawAmmo(
 		value = HUD_Stats(STAT_SHELLS + num - 1);
 	}
 
-	if (style < 2) {
+	if (style < 2 || style == 3) {
 		// simply draw number
 		SCR_HUD_DrawNum(hud, value, low, scale, style, digits, s_align, proportional);
 	}

--- a/src/hud_ammo.c
+++ b/src/hud_ammo.c
@@ -170,7 +170,7 @@ static void SCR_HUD_DrawAmmo(
 
 	if (style < 2 || style == 3) {
 		// simply draw number
-		SCR_HUD_DrawNum(hud, value, low, scale, style, digits, s_align, proportional);
+		SCR_HUD_DrawNum(hud, value, style == 3 ? false : low, scale, style, digits, s_align, proportional);
 	}
 	else {
 		// else - draw classic ammo-count box with background

--- a/src/hud_common.c
+++ b/src/hud_common.c
@@ -351,6 +351,14 @@ void SCR_HUD_DrawNum2(
 				Draw_SAlt_String(x, y, buf, scale, proportional);
 			}
 			else {
+				if(style == 3) {
+					// golden numbers
+					for(i = 0; i < len; i++) {
+						if(isdigit(buf[i])) {
+							buf[i] = 18 + buf[i] - '0';
+						}
+					}
+				}
 				Draw_SString(x, y, buf, scale, proportional);
 			}
 			break;


### PR DESCRIPTION
adds style 3 to most numeric hud elements (health, ammo, armor, gameclock, ...) which makes the text small gold letters from the console charset