### PR TITLE
Improve error handling

### DIFF
--- a/src/pr_cmds.c
+++ b/src/pr_cmds.c
@@ -69,7 +69,7 @@ void PF_error (void)
 	ed = PROG_TO_EDICT(pr_global_struct->self);
 	ED_Print (ed);
 
-	SV_Error ("Program error");
+	SV_Error ("Program error (PF_error)");
 }
 
 /*
@@ -93,7 +93,7 @@ void PF_objerror (void)
 	ED_Print (ed);
 	ED_Free (ed);
 
-	SV_Error ("Program error");
+	SV_Error ("Program error (PF_objerror)");
 }
 
 

--- a/src/pr_exec.c
+++ b/src/pr_exec.c
@@ -199,7 +199,7 @@ void PR_StackTrace (void)
 	}
 
 	pr_stack[pr_depth].f = pr_xfunction;
-	for (i=pr_depth ; i>=0 ; i--)
+	for (i=pr_depth ; i>0 ; i--)
 	{
 		f = pr_stack[i].f;
 
@@ -278,7 +278,7 @@ void PR_RunError (char *error, ...)
 
 	pr_depth = 0; // dump the stack so SV_Error can shutdown functions
 
-	SV_Error ("Program error");
+	SV_Error ("Program error (PR_RunError)");
 }
 
 /*

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -220,6 +220,8 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 	extern qbool	sv_allow_cheats;
 	extern cvar_t	sv_cheats, sv_paused, sv_bigcoords;
 
+	sv_error = false;
+
 	// store old map name
 	snprintf (oldmap, MAP_NAME_LEN, "%s", sv.mapname);
 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -276,21 +276,15 @@ void SV_Shutdown (char *finalmsg)
 SV_Error
 
 Sends a datagram to all the clients informing them of the server crash,
-then exits
+then stops the server
 ================
 */
 void SV_Error (char *error, ...)
 {
-	static qbool inerror = false;
 	static char string[1024];
 	va_list argptr;
 
 	sv_error = true;
-
-	if (inerror)
-		Sys_Error ("SV_Error: recursively entered (%s)", string);
-
-	inerror = true;
 
 	va_start (argptr, error);
 	vsnprintf (string, sizeof (string), error, argptr);
@@ -298,7 +292,8 @@ void SV_Error (char *error, ...)
 
 	SV_Shutdown (va ("SV_Error: %s\n", string));
 
-	Sys_Error ("SV_Error: %s", string);
+	Host_EndGame();
+	Host_Error("SV_Error: %s", string);
 }
 
 static void SV_FreeHeadDelayedPacket(client_t *cl) {

--- a/src/sys_posix.c
+++ b/src/sys_posix.c
@@ -125,6 +125,7 @@ void Sys_Error(char *error, ...)
 		fprintf(qconsole_log, "Error: %s\n", string);
 
 	Host_Shutdown ();
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Error", string, NULL);
 	exit(1);
 }
 


### PR DESCRIPTION
see #826

- progs errors do not crash ezquake anymore, instead the server is stopped and errors are displayed in the console
- the linux version now shows a message box instead of straight up exiting

ideally some more errors to change would be suggested 