### PR TITLE
Allow server browser scrolling when serverinfo open

### DIFF
--- a/src/EX_browser.c
+++ b/src/EX_browser.c
@@ -2201,46 +2201,6 @@ void Serverinfo_Key(int key)
 		case K_BACKSPACE:
 			Serverinfo_Stop();
 			break;
-		case K_PGUP:
-			if (CTab_GetCurrentId(&sb_tab) == SBPG_PLAYERS)
-			{
-				if (keydown[K_CTRL])
-					Players_pos = 0;
-				else
-					Players_pos--;
-				Players_pos = max(0, Players_pos);
-				Serverinfo_Change(all_players[Players_pos]->serv);
-			}
-			else
-			{
-				if (keydown[K_CTRL])
-					Servers_pos = 0;
-				else
-					Servers_pos--;
-				Servers_pos = max(0, Servers_pos);
-				Serverinfo_Change(servers[Servers_pos]);
-			}
-			break;
-		case K_PGDN:
-			if (CTab_GetCurrentId(&sb_tab) == SBPG_PLAYERS)
-			{
-				if (keydown[K_CTRL])
-					Players_pos = all_players_n - 1;
-				else
-					Players_pos++;
-				Players_pos = min(all_players_n-1, Players_pos);
-				Serverinfo_Change(all_players[Players_pos]->serv);
-			}
-			else
-			{
-				if (keydown[K_CTRL])
-					Servers_pos = serversn_passed-1;
-				else
-					Servers_pos++;
-				Servers_pos = min(serversn_passed-1, Servers_pos);
-				Serverinfo_Change(servers[Servers_pos]);
-			}
-			break;
 		case K_TAB:
 			if (keydown[K_SHIFT]) {
 				serverinfo_pos--;
@@ -2297,6 +2257,23 @@ void Serverinfo_Key(int key)
 		case 'i':
 			SB_PingTree_DumpPath(&show_serverinfo->address);
 			break;
+		case K_MWHEELUP:
+	        case K_UPARROW:
+	        case K_PGUP:
+	          if (!keydown[K_CTRL]) {
+		    Servers_pos--;
+		    Servers_pos = max(0, Servers_pos);
+		    Serverinfo_Change(servers[Servers_pos]);
+		    break;
+	          }
+	        case K_MWHEELDOWN:
+	        case K_DOWNARROW:
+	        case K_PGDN:
+	          if (!keydown[K_CTRL]) {
+		    Servers_pos++;
+		    Servers_pos = min(serversn_passed - 1, Servers_pos);
+		    Serverinfo_Change(servers[Servers_pos]);
+	          }
 		default:
 			switch (serverinfo_pos)
 			{


### PR DESCRIPTION
It's annoying that you have to esc out before using the arrow keys / mouse wheel when you browse servers to check who is online. This PR allows you to keep the serverinfo window open when scrolling up or down. Note that the old behavior for scrolling up / down in the individual serverinfo tabs is preserved with ctrl+arrow etc. 

We do lose the old ctrl+arrow behavior where you could go to the end of the server list by doing ctrl+downarrow, but I think it's such a rare use case that it's fine.