### PR TITLE
Additions to hud_frags element

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -7436,15 +7436,23 @@
       "desc": "Toggles alignment of players nick and team name in frags HUD element.",
       "group-id": "19",
       "remarks": "Use 'frags shownames 1' and/or 'frags showteams 1' to show names and team names of players.",
-      "type": "boolean",
+      "type": "integer",
       "values": [
         {
           "description": "Rows aligned to the left side, names and team tags are on the right side of frag counts.",
-          "name": "false"
+          "name": "0"
         },
         {
           "description": "Rows aligned to the right side, names and team tags are on the left side of frag counts.",
-          "name": "true"
+          "name": "1"
+        },
+        {
+          "description": "Rows aligned toward the inside of each column.",
+          "name": "2"
+        },
+        {
+          "description": "Rows aligned toward the outside of each column.",
+          "name": "3"
         }
       ]
     },
@@ -7595,7 +7603,7 @@
           "name": "2"
         },
         {
-          "description": "Similar to 0.",
+          "description": "No pointer or indicator.",
           "name": "3"
         },
         {

--- a/help_variables.json
+++ b/help_variables.json
@@ -7636,6 +7636,20 @@
     "hud_frags_vertical": {
       "desc": "Switches vertical rendering of frags bar.",
       "group-id": "19",
+      "values": [
+        {
+          "description": "No vertical rendering.",
+          "name": "0"
+        },
+        {
+          "description": "Legacy vertical rendering.",
+          "name": "1"
+        },
+        {
+          "description": "New vertical rendering: split columns evenly based on number of players.",
+          "name": "2"
+        }
+      ],
       "type": "float"
     },
     "hud_gameclock_align_x": {

--- a/src/hud_frags.c
+++ b/src/hud_frags.c
@@ -322,23 +322,30 @@ static void Frags_DrawColors(
 		}
 	}
 	else {
-		if (use_wipeout && (isdead == 1) && (timetospawn > 0) && (timetospawn < 999)){
-			color.c = RGBA_TO_COLOR(0xFF, 0xFF, 0x00, (byte)(1 * 255));
-			snprintf(buf, sizeof(buf), "%d", timetospawn);
-		}
-		else if (use_wipeout && (isdead == 2)){
-			if(!hidefrags) {
+		if (use_wipeout) {
+			if (isdead == 1 && timetospawn > 0 && timetospawn < 999) {
+				color.c = RGBA_TO_COLOR(0xFF, 0xFF, 0x00, (byte)(1 * 255));
+			} 
+			else if (isdead == 2) {
 				color.c = RGBA_TO_COLOR(0x33, 0x33, 0x33, (byte)(1 * 255));
-				snprintf(buf, sizeof(buf), "%d", frags);
+			} 
+			else {
+				color.c = RGBA_TO_COLOR(0xFF, 0xFF, 0xFF, (byte)(1 * 255));
 			}
 		}
 		else {
 			color.c = RGBA_TO_COLOR(0xFF, 0xFF, 0xFF, (byte)(1 * 255));
+		}
 
-			if (!use_wipeout || !hidefrags)
-				snprintf(buf, sizeof(buf), "%d", frags);
-			else
-				snprintf(buf, sizeof(buf), "%s", " ");
+		// Determine snprintf content
+		if (use_wipeout && isdead == 1 && timetospawn > 0 && timetospawn < 999) {
+			snprintf(buf, sizeof(buf), "%d", timetospawn);
+		} 
+		else if (use_wipeout && hidefrags) {
+			snprintf(buf, sizeof(buf), "%s", " ");
+		} 
+		else {
+			snprintf(buf, sizeof(buf), "%d", frags);
 		}
 
 		// Normal text size. (meag: why -3?)

--- a/src/hud_frags.c
+++ b/src/hud_frags.c
@@ -880,9 +880,13 @@ static void SCR_HUD_DrawFrags(hud_t *hud)
 	if (hud_frags_strip->integer) {
 		// Auto set the number of rows / cols based on the number of players.
 		// (This is kinda fucked up, but I won't mess with it for the sake of backwards compability).
-		if (hud_frags_vertical->value) {
+		if (hud_frags_vertical->value == 1) {
 			a_cols = min((n_players + rows - 1) / rows, cols);
 			a_rows = min(rows, n_players);
+		}
+		else if (hud_frags_vertical->value == 2) {
+			a_cols = min(n_teams, cols);
+			a_rows = min(rows, ((n_players % a_cols) ? n_players/a_cols + 1 : n_players/a_cols));
 		}
 		else {
 			a_rows = min((n_players + cols - 1) / cols, rows);

--- a/src/hud_frags.c
+++ b/src/hud_frags.c
@@ -338,6 +338,9 @@ static void Frags_DrawColors(
 				Draw_Fill(x + width - 1, y - 1, 1, height + 2, 0x4f);
 				Draw_Fill(x, y + height, width, 1, 0x4f);
 				break;
+			case 3:
+				// Draw nothing
+				break;
 			case 0:
 			default:
 				Draw_SCharacterP(x - 2 - 2 * d, brack_posy, 16, scale, proportional); // [


### PR DESCRIPTION
hud_frags_style 3 - shows no indicator around self frags
hud_frags_vertical 2 - splits columns evenly based on number of players without having to manually change row count
Also: frags element has been extended to display CA/Wipeout game state.
![image](https://github.com/QW-Group/ezquake-source/assets/71472647/c779f153-1957-4f5e-95b4-7676d1589dd4)
