### PR TITLE
Fix RGBToString conversion

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -181,9 +181,16 @@ byte* StringToRGB(char *s)
 }
 
 void RGBToString(const byte *rgb, char *s) {
-	s[0] = '0' + (rgb[0] / 255) * 9.0f;
-	s[1] = '0' + (rgb[1] / 255) * 9.0f;
-	s[2] = '0' + (rgb[2] / 255) * 9.0f;
+	// Scale down each value from 0x0 to 0xff to the range of 0x0 to 0xf.
+	byte r = rgb[0] * 0xf / 0xff;
+	byte g = rgb[1] * 0xf / 0xff;
+	byte b = rgb[2] * 0xf / 0xff;
+
+	// Convert the value to its hex representation. The characters will be
+	// used in a "&cRGB" string.
+	s[0] = (r < 10) ? ('0' + r) : ('a' + r - 0xa);
+	s[1] = (g < 10) ? ('0' + g) : ('a' + g - 0xa);
+	s[2] = (b < 10) ? ('0' + b) : ('a' + b - 0xa);
 }
 
 /*


### PR DESCRIPTION
The `RGBToString` function is intended to serve as the inverse of `TrackerStringToRGB_W`, which is responsible for translating `[0-9]` to `[0-255]`.

However, the previous version of `RGBToString` did not function correctly. For instance, the value `255` was inaccurately converted to `9`, which is incorrect (it should be `15`).

This patch aims to address the issue and correctly convert the bytes to their downscaled hex character representation."