### PR TITLE
CMD: Support exec of http/https urls

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -498,6 +498,7 @@ void Cmd_Exec_f (void)
 		strlcpy(name, Cmd_Argv(1), sizeof(name));
 
 		curl = curl_easy_init();
+		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
 		curl_easy_setopt(curl, CURLOPT_URL, name);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &f);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -498,6 +498,7 @@ void Cmd_Exec_f (void)
 		strlcpy(name, Cmd_Argv(1), sizeof(name));
 
 		curl = curl_easy_init();
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
 		curl_easy_setopt(curl, CURLOPT_URL, name);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &f);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cfg_download_callback);


### PR DESCRIPTION
This change extends the `exec` function to support fetching scripts from a remote location via `http` or `https`.

My intention with this addition is to make it easier to share and ensure that everyone on my team is using the same teamplay config.