### PR TITLE
CL_ParseStufftext: Add list of allowed commands to process

### DIFF
--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -276,6 +276,7 @@ cvar_t cl_debug_weapon_view     = { "cl_debug_weapon_view", "0" };
 static void OnChange_stufftext_allowed_commands(cvar_t *var, char *string, qbool *cancel);
 hashtable_t *stufftext_allowed_commands_hash;
 cvar_t cl_stufftext_allowed_commands = { "cl_stufftext_allowed_commands", "", 0, OnChange_stufftext_allowed_commands };
+cvar_t cl_stufftext_prevent_nested_commands = { "cl_stufftext_prevent_nested_commands", "0" };
 
 /// persistent client state
 clientPersistent_t	cls;
@@ -1939,6 +1940,7 @@ static void CL_InitLocal(void)
 
 	// stufftext restrictions
 	Cvar_Register(&cl_stufftext_allowed_commands);
+	Cvar_Register(&cl_stufftext_prevent_nested_commands);
 
 	snprintf(st, sizeof(st), "ezQuake %i", REVISION);
 

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -3065,6 +3065,7 @@ void CL_ParsePrint (void)
 void CL_ParseStufftext (void) 
 {
 	extern cvar_t cl_stufftext_allowed_commands;
+	extern cvar_t cl_stufftext_prevent_nested_commands;
 	extern hashtable_t *stufftext_allowed_commands_hash;
 	char *s = MSG_ReadString(), *c;
 
@@ -3078,6 +3079,12 @@ void CL_ParseStufftext (void)
 			Com_Printf("Prevented server from running %s", s);
 			return;
 		}
+	}
+
+	if (cl_stufftext_prevent_nested_commands.integer && strchr(s, ';') != NULL)
+	{
+		Com_Printf("Prevented server from running %s", s);
+		return;
 	}
 
 	// Always process demomarks, regardless of who inserted them

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -3073,10 +3073,17 @@ void CL_ParseStufftext (void)
 	{
 		// We need to duplicate the string before it is tokenized and
 		// trimmed since strtok mutates the original input.
-		c = str_trim(strtok(Q_strdup(s), " "));
+		c = Q_strdup(s);
+		c = str_trim(strtok(c, " "));
+
+		// The server can send multiple commands at the same time,
+		// separated by a new line.
+		// When a map is changed it sends "changing\nreconnect", to make
+		// this a hashable value we'll replace '\n' with '_'.
+		str_replace_char(c, '\n', '_');
 		if (!Hash_Get(stufftext_allowed_commands_hash, c))
 		{
-			Com_Printf("Prevented server from running %s", s);
+			Com_DPrintf("Prevented server from running %s", s);
 			return;
 		}
 	}

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -3090,7 +3090,7 @@ void CL_ParseStufftext (void)
 
 	if (cl_stufftext_prevent_nested_commands.integer && strchr(s, ';') != NULL)
 	{
-		Com_Printf("Prevented server from running %s", s);
+		Com_DPrintf("Prevented server from running %s", s);
 		return;
 	}
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -363,6 +363,16 @@ char *str_trim(char *str)
 	return orig_str;
 }
 
+void str_replace_char(char *str, const char old, const char new)
+{
+	char *c = NULL;
+
+	while ((c = strchr(str, old)) != NULL)
+	{
+		*c = new;
+	}
+}
+
 int HexToInt(char c)
 {
 	if (isdigit(c))

--- a/src/utils.h
+++ b/src/utils.h
@@ -53,6 +53,8 @@ void str_align_right (char *target, size_t size, const char *source, size_t leng
 // skip whitespace from both beginning and end
 char *str_trim(char *str);
 
+void str_replace_char(char *str, const char old, const char new);
+
 int HexToInt(char c);
 
 ///


### PR DESCRIPTION
By setting cl_stufftext_allowed_commands, you can now control what commands the server is allowed to execute on the client.