### PR TITLE
BUILD: disable the x11 gamma workaround logic by default in builds as…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ else
 
     # Resolve all symbols at link time
     ifeq ($(SYS),Linux)
-    	CFLAGS += -DX11_GAMMA_WORKAROUND
+        #CFLAGS += -DX11_GAMMA_WORKAROUND
         LDFLAGS_c += -Wl,--no-undefined
     endif
 


### PR DESCRIPTION
… it's no longer needed