### PR TITLE
CL_IDRIVE: rename to CL_SOCD and make default

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1714,20 +1714,28 @@
         }
       ]
     },
-    "cl_iDrive": {
-      "default": "0",
-      "desc": "Emulates \"strafe script\". When turned on, you will always change direction instead of stopping when holding opposing movement keys +moveleft and +moveright, or +forward and +back.",
+    "cl_socd": {
+      "default": "1",
+      "desc": "Determines movement behavior when holding opposing directional keys.",
       "group-id": "9",
-      "remarks": "Reported in your f_ruleset reply with the '+i' flag.\nCan not be changed during a match.",
-      "type": "boolean",
+      "remarks": "",
+      "type": "integer",
       "values": [
         {
-          "description": "Pressing keys for both directions will stop movement on that axis.",
-          "name": "false"
+          "description": "Legacy behavior (no priority)",
+          "name": "0"
         },
         {
-          "description": "Auto-releases one of the keys when both directions are pressed.",
-          "name": "true"
+          "description": "Last Input Priority",
+          "name": "1"
+        },
+        {
+          "description": "Absolute Priority: moveleft",
+          "name": "2"
+        },
+        {
+          "description": "Absolute Priority: moveright",
+          "name": "3"
         }
       ]
     },

--- a/src/cl_input.c
+++ b/src/cl_input.c
@@ -31,7 +31,7 @@ cvar_t cl_c2sImpulseBackup = { "cl_c2sImpulseBackup","3" };
 cvar_t cl_c2sdupe = { "cl_c2sdupe", "0" };
 cvar_t cl_forwardspeed = { "cl_forwardspeed","400" };
 cvar_t cl_smartjump = { "cl_smartjump", "1" };
-cvar_t cl_iDrive = { "cl_iDrive", "0", 0, Rulesets_OnChange_cl_iDrive };
+cvar_t cl_socd = { "cl_socd", "1", 0, Rulesets_OnChange_cl_iDrive };
 cvar_t cl_movespeedkey = { "cl_movespeedkey","2.0" };
 cvar_t cl_nodelta = { "cl_nodelta","0" };
 cvar_t cl_pitchspeed = { "cl_pitchspeed","150" };
@@ -762,7 +762,7 @@ void CL_BaseMove(usercmd_t* cmd)
 
 	VectorCopy(cl.viewangles, cmd->angles);
 
-	if (cl_iDrive.integer) {
+	if (cl_socd.integer) {
 		float s1, s2;
 
 		if (in_strafe.state & 1) {
@@ -770,10 +770,22 @@ void CL_BaseMove(usercmd_t* cmd)
 			s2 = CL_KeyState(&in_left, false);
 
 			if (s1 && s2) {
-				if (in_right.downtime > in_left.downtime)
-					s2 = 0;
-				if (in_right.downtime < in_left.downtime)
-					s1 = 0;
+				if (in_right.downtime > in_left.downtime) {
+					if (cl_socd.integer == 1)
+						s2 = 0;
+					else if (cl_socd.integer == 2)
+						s1 = 0;	// Prioritize moveleft
+					else
+						s2 = 0;	// Prioritize moveright	
+				}
+				if (in_right.downtime < in_left.downtime) {
+					if (cl_socd.integer == 1)
+						s1 = 0;
+					else if (cl_socd.integer == 2)
+						s1 = 0; // Prioritize moveleft
+					else
+						s2 = 0;	// Prioritize moveright
+				}
 			}
 
 			cmd->sidemove += sidespeed * s1;
@@ -784,10 +796,22 @@ void CL_BaseMove(usercmd_t* cmd)
 		s2 = CL_KeyState(&in_moveleft, false);
 
 		if (s1 && s2) {
-			if (in_moveright.downtime > in_moveleft.downtime)
-				s2 = 0;
-			if (in_moveright.downtime < in_moveleft.downtime)
-				s1 = 0;
+			if (in_moveright.downtime > in_moveleft.downtime) {
+				if (cl_socd.integer == 1)
+					s2 = 0;
+				else if (cl_socd.integer == 2)
+					s1 = 0;	// Prioritize moveleft
+				else
+					s2 = 0;	// Prioritize moveright	
+			}
+			if (in_moveright.downtime < in_moveleft.downtime){
+				if (cl_socd.integer == 1)
+					s1 = 0;
+				else if (cl_socd.integer == 2)
+					s1 = 0;	// Prioritize moveleft
+				else
+					s2 = 0;	// Prioritize moveright	
+			}
 		}
 
 		cmd->sidemove += sidespeed * s1;
@@ -1226,7 +1250,7 @@ void CL_InitInput(void)
 	Cvar_Register(&cl_yawspeed);
 	Cvar_Register(&cl_pitchspeed);
 	Cvar_Register(&cl_anglespeedkey);
-	Cvar_Register(&cl_iDrive);
+	Cvar_Register(&cl_socd);
 
 	Cvar_SetCurrentGroup(CVAR_GROUP_INPUT_MISC);
 	Cvar_Register(&lookspring);

--- a/src/fchecks.c
+++ b/src/fchecks.c
@@ -47,7 +47,7 @@ extern cvar_t allow_scripts;
 extern cvar_t cl_delay_packet;
 extern cvar_t r_fullbrightSkins;
 extern cvar_t cl_fakeshaft;
-extern cvar_t cl_iDrive;
+extern cvar_t cl_socd;
 
 
 static void FChecks_VersionResponse (void)
@@ -233,8 +233,8 @@ const char* FChecks_RulesetAdditionString(void)
 	// enemy skin forcing enabled
 	APPENDFEATURE((enemyforceskins.integer),"f");
 
-	// cl_iDrive - strafing aid
-	APPENDFEATURE((cl_iDrive.integer),"i");
+	// cl_socd (formerly cl_iDrive)
+	APPENDFEATURE((cl_socd.integer),"i");
 	#undef APPENDFEATURE
 
 	if (strlen(feat_on_buf) > 1) {

--- a/src/host.c
+++ b/src/host.c
@@ -584,6 +584,8 @@ static void Host_RegisterLegacyCvars(void)
 	Cmd_AddLegacyCommand("contrast", v_contrast.name);
 	Cmd_AddLegacyCommand("gl_gammacorrection", "vid_gammacorrection");
 
+	Cmd_AddLegacyCommand("cl_idrive", "cl_socd");
+
 	// if you don't like renaming things in this way, let's have some talk with tea - johnnycz
 	Cmd_AddLegacyCommand("con_sound_mm1_file", "s_mm1_file");
 	Cmd_AddLegacyCommand("con_sound_mm2_file", "s_mm2_file");

--- a/src/rulesets.c
+++ b/src/rulesets.c
@@ -618,8 +618,8 @@ void Rulesets_OnChange_cl_iDrive(cvar_t *var, char *value, qbool *cancel)
 		return;
 	}
 
-	if (fval != 0 && fval != 1) {
-		Com_Printf("Invalid value for %s, use 0 or 1.\n", var->name);
+	if (fval != 0 && fval != 1 && fval != 2 && fval != 3) {
+		Com_Printf("Invalid value for %s, use 0 or 1 or 2 or 3.\n", var->name);
 		*cancel = true;
 		return;
 	}


### PR DESCRIPTION
This renames the confusing "cl_iDrive" cvar to "cl_socd" which is more in line with what is used elsewhere. I also made "1" the default value and added a couple more options to match the functionality of wooting and razer keyboards.

cl_socd
0: Legacy behavior (no priority)
1: Last Input Priority
2: Absolute Priority: moveleft
3: Absolute Priority: moveright