### PR TITLE
STYLE: Fix some c89 violations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ RMDIR ?= rm -rf
 MKDIR ?= mkdir -p
 JSON2C ?= ./json2c.sh
 
-CFLAGS ?= -O2 -Wall -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-strict-aliasing -Werror=strict-prototypes -Werror=old-style-definition -g -MMD $(INCLUDES)
+CFLAGS ?= -std=gnu89 -O2 -Wall -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-strict-aliasing -Werror=strict-prototypes -Werror=old-style-definition -g -MMD $(INCLUDES)
 RCFLAGS ?=
 LDFLAGS ?=
 LIBS ?=

--- a/src/glm_aliasmodel.c
+++ b/src/glm_aliasmodel.c
@@ -291,6 +291,7 @@ static void GLM_QueueAliasModelDrawImpl(
 	aliasmodel_draw_instructions_t* instr;
 	int textureSampler = -1;
 	extern cvar_t gl_spec_xray;
+	int i;
 
 	// Compile here so we can work out how many samplers we have free to allocate per draw-call
 	if (!GLM_CompileAliasModelProgram()) {
@@ -364,8 +365,8 @@ static void GLM_QueueAliasModelDrawImpl(
 		int bc = 16 * (bound(0, ent->scoreboard->bottomcolor, 13)) + 8;
 		byte top[] = { host_basepal[tc * 3], host_basepal[tc * 3 + 1], host_basepal[tc * 3 + 2] };
 		byte bot[] = { host_basepal[bc * 3], host_basepal[bc * 3 + 1], host_basepal[bc * 3 + 2] };
-		for(int i = 0; i < 3; i++) uniform->plrtopcolor[i] = (float)top[i] / 256.0f;
-		for(int i = 0; i < 3; i++) uniform->plrbotcolor[i] = (float)bot[i] / 256.0f;
+		for(i = 0; i < 3; i++) uniform->plrtopcolor[i] = (float)top[i] / 256.0f;
+		for(i = 0; i < 3; i++) uniform->plrbotcolor[i] = (float)bot[i] / 256.0f;
 	}
 
 	// Add to queues

--- a/src/in_sdl2.c
+++ b/src/in_sdl2.c
@@ -471,7 +471,7 @@ static void
 IN_StartupJoystick (void)
 {
 	SDL_Joystick	*jdev;
-	int		numdevs;
+	int		numdevs, i;
 
 	//COM_CheckParm ("-joystick");
 	
@@ -520,7 +520,7 @@ IN_StartupJoystick (void)
 	}
 
 	/*  Check if we can open any of them.  */
-	for (int i = 0;  i < numdevs;  ++i) {
+	for (i = 0;  i < numdevs;  ++i) {
 		jdev = SDL_JoystickOpen (i);
 		if (jdev) {
 			Com_Printf ("Detected joystick %d: %d axes, %d buttons: \"%s\"\n",

--- a/src/r_brushmodel_load.c
+++ b/src/r_brushmodel_load.c
@@ -1021,6 +1021,7 @@ static int Mod_LoadDecoupledLM(dlminfo_t* lminfos, int surfnum, msurface_t *out)
 {
 	dlminfo_t *lminfo;
 	unsigned short lmwidth, lmheight;
+	int i, j;
 
 	if (lminfos == NULL) {
 		return -1;
@@ -1035,8 +1036,8 @@ static int Mod_LoadDecoupledLM(dlminfo_t* lminfos, int surfnum, msurface_t *out)
 		return -1;
 	}
 
-	for (int i = 0; i < 2; i++) {
-		for (int j = 0; j < 4; j++) {
+	for (i = 0; i < 2; i++) {
+		for (j = 0; j < 4; j++) {
 			out->lmvecs[i][j] = LittleFloat(lminfo->vecs[i][j]);
 		}
 	}


### PR DESCRIPTION
The wiki specifies that C89 is the target standard. In reality the codebase adheres to GNU89. When actually enforcing this the behavior of MinGW cross-compilation changes, which allows JSON_INTEGER_FORMAT to work as intended.

Later standards automatically enable __USE_MINGW_ANSI_STDIO=1 in MinGW which is the cause of the jansson breakage.

It seems to be fairly common to combine __STDC_FORMAT_MACROS=1 and __USE_MINGW_ANSI_STDIO=0 in projects that disable it.