### PR TITLE
RENDERER: Add option to filter out collinear vertices.

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -15627,6 +15627,23 @@
       "remarks": "See also: r_nearclip.",
       "type": "float"
     },
+    "r_remove_collinear_vertices": {
+        "default": "0",
+        "desc": "Filter out vertices causing triangles to have zero area. These types of triangles are a sore spot in some GPUs that risk introducing glitches. An expected side effect is a risk of seeing a sparkling pixel.",
+        "group-id": "35",
+        "remarks": "For macOS arm64 this is force-enabled to prevent cheating. This filtering is a temporary workaround before adding code to avoid generating such triangles in the first place.",
+        "type": "boolean",
+        "values": [
+            {
+                "description": "Disable filtering of collinear vertices.",
+                "name": "false"
+            },
+            {
+                "description": "Enable filtering of collinear vertices.",
+                "name": "true"
+            }
+        ]
+    },
     "r_fastsky": {
       "default": "0",
       "group-id": "51",

--- a/src/r_rmain.c
+++ b/src/r_rmain.c
@@ -114,6 +114,15 @@ static void OnDynamicLightingChange(cvar_t* var, char* value, qbool* cancel)
 	}
 }
 
+static void OnRemoveCollinearVerticesChanged(cvar_t* var, char* value, qbool* cancel)
+{
+#if defined(__APPLE__) && defined(__aarch64__)
+	// At least arm64 based MacBook laptops are known to require this workaround.
+	Cvar_SetIgnoreCallback(var, "1");
+	*cancel = true;
+#endif
+}
+
 cvar_t cl_multiview                        = {"cl_multiview", "0" };
 cvar_t cl_mvdisplayhud                     = {"cl_mvdisplayhud", "1"};
 cvar_t cl_mvhudvertical                    = {"cl_mvhudvertical", "0"};
@@ -237,6 +246,8 @@ cvar_t gl_outline_color_enemy              = {"gl_outline_color_enemy", ""};
 cvar_t gl_smoothmodels                     = {"gl_smoothmodels", "1"};
 
 cvar_t gl_vbo_clientmemory                 = {"gl_vbo_clientmemory", "0", CVAR_LATCH_GFX };
+
+cvar_t r_remove_collinear_vertices         = {"r_remove_collinear_vertices", "0", 0, OnRemoveCollinearVerticesChanged};
 
 //Returns true if the box is completely outside the frustom
 qbool R_CullBox(vec3_t mins, vec3_t maxs)
@@ -749,6 +760,8 @@ void R_Init(void)
 	Cvar_Register(&cl_mvinset_size_y);
 	Cvar_Register(&cl_mvinset_top);
 	Cvar_Register(&cl_mvinset_right);
+
+	Cvar_Register(&r_remove_collinear_vertices);
 
 	Cvar_ResetCurrentGroup();
 


### PR DESCRIPTION
This is a temporary workaround primarily targeted at macOS arm64 on which the GPU has a high risk of clipping nearby triangles if zero sized triangles are fed to the GPU. At best this bug introduces rendering glitches from looking into the void, at worst it allows the player to see enemies behind walls in matches.

The workaround is force-enabled on macOS arm64. But there have been mysterious rendering issues with missing surfaces in the past, so other targets may opt-in to enable it and see if it helps.