### PR TITLE
Ignore the /build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ SysPrintf.log
 *.glsl.c
 vcpkg_installed/
 src/.msversion.h
-/build-*/
+/build*/
 
 !.gitignore


### PR DESCRIPTION
As recommended in `BUILD.md`, the build directory should be created when building from source, so it should probably be added to `.gitignore` as well.