### PR TITLE
HUD: add hud_gun[2-8]_frame_hide

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -8545,6 +8545,11 @@
       "group-id": "19",
       "type": "string"
     },
+    "hud_gun2_frame_hide": {
+      "desc": "Hide the frame unless you have the weapon.",
+      "group-id": "19",
+      "type": "integer"
+    },
     "hud_gun2_item_opacity": {
       "group-id": "19",
       "type": "float"
@@ -8641,6 +8646,11 @@
       "desc": "Defines the color of the background of the gun3 HUD element. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
+    },
+    "hud_gun3_frame_hide": {
+      "desc": "Hide the frame unless you have the weapon.",
+      "group-id": "19",
+      "type": "integer"
     },
     "hud_gun3_item_opacity": {
       "group-id": "19",
@@ -8739,6 +8749,11 @@
       "group-id": "19",
       "type": "string"
     },
+    "hud_gun4_frame_hide": {
+      "desc": "Hide the frame unless you have the weapon.",
+      "group-id": "19",
+      "type": "integer"
+    },
     "hud_gun4_item_opacity": {
       "group-id": "19",
       "type": "float"
@@ -8835,6 +8850,11 @@
       "desc": "Defines the color of the background of the gun5 HUD element. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
+    },
+    "hud_gun5_frame_hide": {
+      "desc": "Hide the frame unless you have the weapon.",
+      "group-id": "19",
+      "type": "integer"
     },
     "hud_gun5_item_opacity": {
       "group-id": "19",
@@ -8933,6 +8953,11 @@
       "group-id": "19",
       "type": "string"
     },
+    "hud_gun6_frame_hide": {
+      "desc": "Hide the frame unless you have the weapon.",
+      "group-id": "19",
+      "type": "integer"
+    },
     "hud_gun6_item_opacity": {
       "group-id": "19",
       "type": "float"
@@ -9030,6 +9055,11 @@
       "group-id": "19",
       "type": "string"
     },
+    "hud_gun7_frame_hide": {
+      "desc": "Hide the frame unless you have the weapon.",
+      "group-id": "19",
+      "type": "integer"
+    },
     "hud_gun7_item_opacity": {
       "group-id": "19",
       "type": "float"
@@ -9126,6 +9156,11 @@
       "desc": "Defines the color of the background of the gun8 HUD element. See HUD manual for more info.",
       "group-id": "19",
       "type": "string"
+    },
+    "hud_gun8_frame_hide": {
+      "desc": "Hide the frame unless you have the weapon.",
+      "group-id": "19",
+      "type": "integer"
     },
     "hud_gun8_item_opacity": {
       "group-id": "19",

--- a/src/hud.c
+++ b/src/hud.c
@@ -904,6 +904,10 @@ void HUD_OnChangeFrameColor(cvar_t *var, char *newval, qbool *cancel)
 //
 void HUD_DrawFrame(hud_t *hud, int x, int y, int width, int height)
 {
+	if (hud->frame_hide) {
+		return;
+	}
+
 	if (!hud->frame->value)
 		return;
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -79,6 +79,7 @@ typedef struct hud_s
     cvar_t* frame;                      // Frame cvar.
     cvar_t* frame_color;                // Frame color cvar.
     byte    frame_color_cache[4];       // Cache for parsed frame color.
+    qbool   frame_hide;                 // Toggle whether frame should be displayed or not.
 
 	cvar_t *opacity;					// The overall opacity of the entire HUD element.
 

--- a/src/hud_guns.c
+++ b/src/hud_guns.c
@@ -181,7 +181,7 @@ static void SCR_HUD_DrawGunByNum(hud_t *hud, int num, float scale, int style, in
 
 static void SCR_HUD_DrawGun2(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *proportional;
+	static cvar_t *scale = NULL, *style, *proportional, *frame_hide;
 	if (scale == NULL) {
 		// first time called
 		scale = HUD_FindVar(hud, "scale");
@@ -191,11 +191,16 @@ static void SCR_HUD_DrawGun2(hud_t *hud)
 	if (cl.spectator == cl.autocam) {
 		SCR_HUD_DrawGunByNum(hud, 2, scale->value, style->value, 0, proportional->integer);
 	}
+
+	frame_hide = HUD_FindVar(hud, "frame_hide");
+	hud->frame_hide = frame_hide->value && !(HUD_Stats(STAT_ITEMS) & IT_SHOTGUN)
+		? true
+		: false;
 }
 
 static void SCR_HUD_DrawGun3(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *proportional;
+	static cvar_t *scale = NULL, *style, *proportional, *frame_hide;
 	if (scale == NULL) {
 		// first time called
 		scale = HUD_FindVar(hud, "scale");
@@ -205,11 +210,16 @@ static void SCR_HUD_DrawGun3(hud_t *hud)
 	if (cl.spectator == cl.autocam) {
 		SCR_HUD_DrawGunByNum(hud, 3, scale->value, style->value, 0, proportional->integer);
 	}
+
+	frame_hide = HUD_FindVar(hud, "frame_hide");
+	hud->frame_hide = frame_hide->value && !(HUD_Stats(STAT_ITEMS) & IT_SUPER_SHOTGUN)
+		? true
+		: false;
 }
 
 static void SCR_HUD_DrawGun4(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *proportional;
+	static cvar_t *scale = NULL, *style, *proportional, *frame_hide;
 	if (scale == NULL) {
 		// first time called
 		scale = HUD_FindVar(hud, "scale");
@@ -219,11 +229,16 @@ static void SCR_HUD_DrawGun4(hud_t *hud)
 	if (cl.spectator == cl.autocam) {
 		SCR_HUD_DrawGunByNum(hud, 4, scale->value, style->value, 0, proportional->integer);
 	}
+
+	frame_hide = HUD_FindVar(hud, "frame_hide");
+	hud->frame_hide = frame_hide->value && !(HUD_Stats(STAT_ITEMS) & IT_NAILGUN)
+		? true
+		: false;
 }
 
 static void SCR_HUD_DrawGun5(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *proportional;
+	static cvar_t *scale = NULL, *style, *proportional, *frame_hide;
 	if (scale == NULL) {
 		// first time called
 		scale = HUD_FindVar(hud, "scale");
@@ -233,11 +248,16 @@ static void SCR_HUD_DrawGun5(hud_t *hud)
 	if (cl.spectator == cl.autocam) {
 		SCR_HUD_DrawGunByNum(hud, 5, scale->value, style->value, 0, proportional->integer);
 	}
+
+	frame_hide = HUD_FindVar(hud, "frame_hide");
+	hud->frame_hide = frame_hide->value && !(HUD_Stats(STAT_ITEMS) & IT_SUPER_NAILGUN)
+		? true
+		: false;
 }
 
 static void SCR_HUD_DrawGun6(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *proportional;
+	static cvar_t *scale = NULL, *style, *proportional, *frame_hide;
 	if (scale == NULL) {
 		// first time called
 		scale = HUD_FindVar(hud, "scale");
@@ -247,11 +267,16 @@ static void SCR_HUD_DrawGun6(hud_t *hud)
 	if (cl.spectator == cl.autocam) {
 		SCR_HUD_DrawGunByNum(hud, 6, scale->value, style->value, 0, proportional->integer);
 	}
+
+	frame_hide = HUD_FindVar(hud, "frame_hide");
+	hud->frame_hide = frame_hide->value && !(HUD_Stats(STAT_ITEMS) & IT_GRENADE_LAUNCHER)
+		? true
+		: false;
 }
 
 static void SCR_HUD_DrawGun7(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *proportional;
+	static cvar_t *scale = NULL, *style, *proportional, *frame_hide;
 	if (scale == NULL) {
 		// first time called
 		scale = HUD_FindVar(hud, "scale");
@@ -261,11 +286,16 @@ static void SCR_HUD_DrawGun7(hud_t *hud)
 	if (cl.spectator == cl.autocam) {
 		SCR_HUD_DrawGunByNum(hud, 7, scale->value, style->value, 0, proportional->integer);
 	}
+
+	frame_hide = HUD_FindVar(hud, "frame_hide");
+	hud->frame_hide = frame_hide->value && !(HUD_Stats(STAT_ITEMS) & IT_ROCKET_LAUNCHER)
+		? true
+		: false;
 }
 
 static void SCR_HUD_DrawGun8(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *wide, *proportional;
+	static cvar_t *scale = NULL, *style, *wide, *proportional, *frame_hide;
 	if (scale == NULL) {
 		// first time called
 		scale = HUD_FindVar(hud, "scale");
@@ -276,6 +306,11 @@ static void SCR_HUD_DrawGun8(hud_t *hud)
 	if (cl.spectator == cl.autocam) {
 		SCR_HUD_DrawGunByNum(hud, 8, scale->value, style->value, wide->value, proportional->integer);
 	}
+
+	frame_hide = HUD_FindVar(hud, "frame_hide");
+	hud->frame_hide = frame_hide->value && !(HUD_Stats(STAT_ITEMS) & IT_LIGHTNING)
+		? true
+		: false;
 }
 
 static void SCR_HUD_DrawGunCurrent(hud_t *hud)
@@ -327,6 +362,7 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 	HUD_Register("gun2", NULL, "Part of your inventory - shotgun.",
 		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawGun2,
@@ -334,6 +370,7 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 	HUD_Register("gun3", NULL, "Part of your inventory - super shotgun.",
 		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawGun3,
@@ -341,6 +378,7 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 	HUD_Register("gun4", NULL, "Part of your inventory - nailgun.",
 		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawGun4,
@@ -348,6 +386,7 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 	HUD_Register("gun5", NULL, "Part of your inventory - super nailgun.",
 		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawGun5,
@@ -355,6 +394,7 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 	HUD_Register("gun6", NULL, "Part of your inventory - grenade launcher.",
 		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawGun6,
@@ -362,6 +402,7 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 	HUD_Register("gun7", NULL, "Part of your inventory - rocket launcher.",
 		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawGun7,
@@ -369,6 +410,7 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 	HUD_Register("gun8", NULL, "Part of your inventory - thunderbolt.",
 		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawGun8,
@@ -377,5 +419,6 @@ void Guns_HudInit(void)
 		"style", "0",
 		"scale", "1",
 		"proportional", "0",
+		"frame_hide", "0",
 		NULL);
 }


### PR DESCRIPTION
This option allows the gun frame to be toggled based on whether or not you actually have the weapon.
![frame-hide-off](https://github.com/user-attachments/assets/03a8df8c-3ae8-45b4-bb32-93f5d08ea89b)
![frame-hide-on](https://github.com/user-attachments/assets/ada02c83-943e-4d11-abeb-6d7bc3db48dd)
