### PR TITLE
Support FTE_PEXT_TRANS and FTE_PEXT_COLOURMOD.

### DIFF
--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -132,6 +132,10 @@ cvar_t  cl_pext_floatcoords  = {"cl_pext_floatcoords", "1"};
 cvar_t cl_pext_alpha = {"cl_pext_alpha", "1"};
 #endif
 
+#ifdef FTE_PEXT_COLOURMOD
+cvar_t cl_pext_colourmod = {"cl_pext_colourmod", "1"};
+#endif
+
 #ifdef CLIENTONLY
 #define PROCESS_SERVERPACKETS_IMMEDIATELY (0)
 #else
@@ -472,6 +476,10 @@ unsigned int CL_SupportedFTEExtensions (void)
 #ifdef FTE_PEXT_TRANS
 	if (cl_pext_alpha.value)
 		fteprotextsupported |= FTE_PEXT_TRANS;
+#endif
+#ifdef FTE_PEXT_COLOURMOD
+	if (cl_pext_colourmod.value)
+		fteprotextsupported |= FTE_PEXT_COLOURMOD;
 #endif
 
 	if (cl_pext_limits.value) {
@@ -1870,6 +1878,9 @@ static void CL_InitLocal(void)
 
 #ifdef FTE_PEXT_TRANS
 	Cvar_Register(&cl_pext_alpha);
+#endif
+#ifdef FTE_PEXT_COLOURMOD
+	Cvar_Register(&cl_pext_colourmod);
 #endif
 
 	Cvar_SetCurrentGroup(CVAR_GROUP_INPUT_KEYBOARD);

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -1875,6 +1875,10 @@ void CL_ParseStatic (qbool extended)
 	ent->frame = es.frame;
 	ent->colormap = vid.colormap;
 	ent->skinnum = es.skinnum;
+#ifdef FTE_PEXT_TRANS
+	// set trans, 0 and 255 are both opaque, represented by alpha 0.
+	ent->alpha = es.trans == 255 ? 0.0f : (float)es.trans / 254.0f;
+#endif
 
 	VectorCopy(es.origin, ent->origin);
 	VectorCopy(es.angles, ent->angles);

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -1879,6 +1879,17 @@ void CL_ParseStatic (qbool extended)
 	// set trans, 0 and 255 are both opaque, represented by alpha 0.
 	ent->alpha = es.trans == 255 ? 0.0f : (float)es.trans / 254.0f;
 #endif
+#ifdef FTE_PEXT_COLOURMOD
+	// Skip colourmod if unset, or identity
+	if ((es.colourmod[0] > 0 || es.colourmod[1] > 0 || es.colourmod[2] > 0) &&
+	    !(es.colourmod[0] == 32 && es.colourmod[1] == 32 && es.colourmod[2] == 32))
+	{
+		ent->r_modelcolor[0] = (float)es.colourmod[0] * 8.0f / 256.0f;
+		ent->r_modelcolor[1] = (float)es.colourmod[1] * 8.0f / 256.0f;
+		ent->r_modelcolor[2] = (float)es.colourmod[2] * 8.0f / 256.0f;
+		ent->renderfx |= RF_FORCECOLOURMOD;
+	}
+#endif
 
 	VectorCopy(es.origin, ent->origin);
 	VectorCopy(es.angles, ent->angles);

--- a/src/client.h
+++ b/src/client.h
@@ -108,6 +108,9 @@ typedef struct
 #ifdef FTE_PEXT_TRANS
 	byte		alpha;
 #endif
+#ifdef FTE_PEXT_COLOURMOD
+	byte		colourmod[3];
+#endif
 
 	byte		vw_index;
 	byte		pm_type;

--- a/src/client.h
+++ b/src/client.h
@@ -105,7 +105,9 @@ typedef struct
 
 	int			flags;			// Dead, gib, etc.
 
+#ifdef FTE_PEXT_TRANS
 	byte		alpha;
+#endif
 
 	byte		vw_index;
 	byte		pm_type;

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -175,6 +175,9 @@ typedef enum
 
 // !!! new things comes to end of list !!!
 
+// G_Map_Extension syscalls
+#define G_EXTENSIONS_FIRST 256
+
 //
 // functions exported by the game subsystem
 //

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1421,6 +1421,9 @@ void PF2_makestatic(edict_t *ent)
 	s->skinnum = ent->v->skin;
 	VectorCopy(ent->v->origin, s->origin);
 	VectorCopy(ent->v->angles, s->angles);
+#ifdef FTE_PEXT_TRANS
+	s->trans = ent->xv.alpha >= 1.0f ? 0 : bound(0, (byte)(ent->xv.alpha * 254.0), 254);
+#endif
 	++sv.static_entity_count;
 
 	// throw the entity away now
@@ -2042,6 +2045,10 @@ static intptr_t EXT_MapExtFieldPtr(intptr_t *args)
 	char *key = VM_ArgPtr(args[1]);
 	if (key)
 	{
+		if (!strcmp(key, "alpha"))
+		{
+			return offsetof(ext_entvars_t, alpha) | GetExtFieldCookie();
+		}
 	}
 
 	return 0;

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1424,6 +1424,14 @@ void PF2_makestatic(edict_t *ent)
 #ifdef FTE_PEXT_TRANS
 	s->trans = ent->xv.alpha >= 1.0f ? 0 : bound(0, (byte)(ent->xv.alpha * 254.0), 254);
 #endif
+#ifdef FTE_PEXT_COLOURMOD
+	if (ent->xv.colourmod[0] != 1.0f && ent->xv.colourmod[1] != 1.0f && ent->xv.colourmod[2] != 1.0f)
+	{
+		s->colourmod[0] = bound(0, ent->xv.colourmod[0] * (256.0f / 8.0f), 255);
+		s->colourmod[1] = bound(0, ent->xv.colourmod[1] * (256.0f / 8.0f), 255);
+		s->colourmod[2] = bound(0, ent->xv.colourmod[2] * (256.0f / 8.0f), 255);
+	}
+#endif
 	++sv.static_entity_count;
 
 	// throw the entity away now
@@ -2048,6 +2056,10 @@ static intptr_t EXT_MapExtFieldPtr(intptr_t *args)
 		if (!strcmp(key, "alpha"))
 		{
 			return offsetof(ext_entvars_t, alpha) | GetExtFieldCookie();
+		}
+		if (!strcmp(key, "colormod"))
+		{
+			return offsetof(ext_entvars_t, colourmod) | GetExtFieldCookie();
 		}
 	}
 

--- a/src/pr_cmds.c
+++ b/src/pr_cmds.c
@@ -2231,6 +2231,14 @@ void PF_makestatic (void)
 #ifdef FTE_PEXT_TRANS
 	s->trans = ent->xv.alpha >= 1.0f ? 0 : bound(0, (byte)(ent->xv.alpha * 254.0), 254);
 #endif
+#ifdef FTE_PEXT_COLOURMOD
+	if (ent->xv.colourmod[0] != 1.0f && ent->xv.colourmod[1] != 1.0f && ent->xv.colourmod[2] != 1.0f)
+	{
+		s->colourmod[0] = bound(0, ent->xv.colourmod[0] * (256.0f / 8.0f), 255);
+		s->colourmod[1] = bound(0, ent->xv.colourmod[1] * (256.0f / 8.0f), 255);
+		s->colourmod[2] = bound(0, ent->xv.colourmod[2] * (256.0f / 8.0f), 255);
+	}
+#endif
 	++sv.static_entity_count;
 
 	// throw the entity away now

--- a/src/pr_cmds.c
+++ b/src/pr_cmds.c
@@ -2228,6 +2228,9 @@ void PF_makestatic (void)
 	s->skinnum = ent->v->skin;
 	VectorCopy(ent->v->origin, s->origin);
 	VectorCopy(ent->v->angles, s->angles);
+#ifdef FTE_PEXT_TRANS
+	s->trans = ent->xv.alpha >= 1.0f ? 0 : bound(0, (byte)(ent->xv.alpha * 254.0), 254);
+#endif
 	++sv.static_entity_count;
 
 	// throw the entity away now

--- a/src/pr_edict.c
+++ b/src/pr_edict.c
@@ -93,6 +93,7 @@ Sets everything to NULL
 void ED_ClearEdict (edict_t *e)
 {
 	memset(e->v, 0, pr_edict_size);
+	memset(&e->xv, 0, sizeof(ext_entvars_t));
 	e->e.lastruntime = 0;
 	e->e.free = false;
 	PR_ClearEdict(e);
@@ -155,7 +156,7 @@ FIXME: walk all entities and NULL out references to this entity
 void ED_Free (edict_t *ed)
 {
 	SV_UnlinkEdict (ed);		// unlink from world bsp
-
+	memset(&ed->xv, 0, sizeof(ext_entvars_t));
 	ed->e.free = true;
 	ed->v->model = 0;
 	ed->v->takedamage = 0;
@@ -922,6 +923,11 @@ const char *ED_ParseEdict (const char *data, edict_t *ent)
 		if (keyname[0] == '_')
 			continue;
 
+		if (!strcmp (keyname, "alpha"))
+		{
+			ent->xv.alpha = bound(0.0f, atof (com_token), 1.0f);
+			continue;
+		}
 		key = ED_FindField (keyname);
 		if (!key)
 		{

--- a/src/pr_edict.c
+++ b/src/pr_edict.c
@@ -928,6 +928,19 @@ const char *ED_ParseEdict (const char *data, edict_t *ent)
 			ent->xv.alpha = bound(0.0f, atof (com_token), 1.0f);
 			continue;
 		}
+		if (!strcmp(keyname, "colormod"))
+		{
+			float v[3];
+			int ret = sscanf(com_token, "%f %f %f", &v[0], &v[1], &v[2]);
+			if (ret == 3 && v[0] > 0.0f && v[1] > 0.0f && v[2] > 0.0f)
+			{
+				ent->xv.colourmod[0] = max(0.0f, v[0]);
+				ent->xv.colourmod[1] = max(0.0f, v[1]);
+				ent->xv.colourmod[2] = max(0.0f, v[2]);
+			}
+			continue;
+		}
+
 		key = ED_FindField (keyname);
 		if (!key)
 		{

--- a/src/progs.h
+++ b/src/progs.h
@@ -63,9 +63,15 @@ typedef struct sv_edict_s
 	double		lastruntime;	// sv.time when SV_RunEntity was last called for this edict (Tonik)
 } sv_edict_t;
 
+typedef struct
+{
+	float	alpha;			// 0 = opaque, 1 = opaque, 0 < x < 1 translucent
+} ext_entvars_t;
+
 typedef struct edict_s
 {
 	sv_edict_t	e;			// server side part of the edict_t
+	ext_entvars_t	xv;
 	entvars_t	*v;			// C exported fields from progs
 } edict_t;
 

--- a/src/progs.h
+++ b/src/progs.h
@@ -66,6 +66,7 @@ typedef struct sv_edict_s
 typedef struct
 {
 	float	alpha;			// 0 = opaque, 1 = opaque, 0 < x < 1 translucent
+	float	colourmod[3];	// r,g,b [0.0 .. 1.0], > 1 overbright
 } ext_entvars_t;
 
 typedef struct edict_s

--- a/src/r_aliasmodel.c
+++ b/src/r_aliasmodel.c
@@ -158,7 +158,8 @@ static void R_RenderAliasModelEntity(
 	int i;
 	model_t* model = ent->model;
 
-	ent->r_modelcolor[0] = -1;  // by default no solid fill color for model, using texture
+	if (!(ent->renderfx & RF_FORCECOLOURMOD))
+		ent->r_modelcolor[0] = -1;  // by default no solid fill color for model, using texture
 	if (color32bit) {
 		// force some color for such model
 		for (i = 0; i < 3; i++) {
@@ -1008,7 +1009,8 @@ void R_AliasModelPrepare(entity_t* ent, int framecount, int* frame1_, int* frame
 	//
 	ent->r_modelalpha = ((ent->renderfx & RF_WEAPONMODEL) && gl_mtexable) ? bound(0, cl_drawgun.value, 1) : 1;
 	ent->r_modelalpha = (ent->alpha ? ent->alpha : ent->r_modelalpha);
-	ent->r_modelcolor[0] = -1;  // by default no solid fill color for model, using texture
+	if (!(ent->renderfx & RF_FORCECOLOURMOD))
+		ent->r_modelcolor[0] = -1;  // by default no solid fill color for model, using texture
 
 	R_AliasSetupLighting(ent);
 

--- a/src/render.h
+++ b/src/render.h
@@ -32,18 +32,19 @@ typedef struct efrag_s {
 	struct efrag_s		*entnext;
 } efrag_t;
 
-#define RF_WEAPONMODEL      1
-#define RF_NOSHADOW         2
-#define RF_LIMITLERP        4
-#define RF_PLAYERMODEL      8
-#define RF_NORMALENT       16
-#define RF_CAUSTICS        32
-#define RF_ALPHABLEND      64   // bit of a hack - always enable blending (used for 2nd pass when multi-texturing disabled)
-#define RF_ADDITIVEBLEND  128
-#define RF_ROCKETPACK     256
-#define RF_LGPACK         512
-#define RF_BEHINDWALL    1024
-#define RF_VWEPMODEL     2048
+#define RF_WEAPONMODEL       1
+#define RF_NOSHADOW          2
+#define RF_LIMITLERP         4
+#define RF_PLAYERMODEL       8
+#define RF_NORMALENT        16
+#define RF_CAUSTICS         32
+#define RF_ALPHABLEND       64   // bit of a hack - always enable blending (used for 2nd pass when multi-texturing disabled)
+#define RF_ADDITIVEBLEND   128
+#define RF_ROCKETPACK      256
+#define RF_LGPACK          512
+#define RF_BEHINDWALL     1024
+#define RF_VWEPMODEL      2048
+#define RF_FORCECOLOURMOD 4096
 
 #define RF_BACKPACK_FLAGS (RF_ROCKETPACK | RF_LGPACK)
 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3565,7 +3565,9 @@ void SV_InitLocal (void)
 #ifdef FTE_PEXT_SPAWNSTATIC2
 	svs.fteprotocolextensions |= FTE_PEXT_SPAWNSTATIC2;
 #endif
-
+#ifdef FTE_PEXT_TRANS
+    svs.fteprotocolextensions |= FTE_PEXT_TRANS;
+#endif
 #ifdef FTE_PEXT2_VOICECHAT
 	svs.fteprotocolextensions2 |= FTE_PEXT2_VOICECHAT;
 #endif

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3568,6 +3568,9 @@ void SV_InitLocal (void)
 #ifdef FTE_PEXT_TRANS
     svs.fteprotocolextensions |= FTE_PEXT_TRANS;
 #endif
+#ifdef FTE_PEXT_COLOURMOD
+	svs.fteprotocolextensions |= FTE_PEXT_COLOURMOD;
+#endif
 #ifdef FTE_PEXT2_VOICECHAT
 	svs.fteprotocolextensions2 |= FTE_PEXT2_VOICECHAT;
 #endif

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -194,6 +194,10 @@ cvar_t sv_pext_mvdsv_serversideweapon = { "sv_pext_mvdsv_serversideweapon", "1" 
 
 cvar_t sv_extlimits = { "sv_extlimits", "2" };
 
+#if defined(FTE_PEXT_TRANS)
+cvar_t sv_pext_ezquake_verfortrans = {"pext_ezquake_verfortrans", "7814", CVAR_NONE};
+#endif
+
 qbool sv_error = false;
 
 client_t *WatcherId = NULL; // QW262
@@ -3500,6 +3504,10 @@ void SV_InitLocal (void)
 	Cvar_Register (&sv_extlimits);
 #ifdef MVD_PEXT1_SERVERSIDEWEAPON
 	Cvar_Register (&sv_pext_mvdsv_serversideweapon);
+#endif
+
+#ifdef FTE_PEXT_TRANS
+	Cvar_Register(&sv_pext_ezquake_verfortrans);
 #endif
 
 	Cvar_Register (&sv_reliable_sound);

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -357,6 +357,33 @@ static void Cmd_New_f (void)
 	}
 #endif
 
+#if defined(FTE_PEXT_TRANS)
+	if (sv_client->fteprotocolextensions & FTE_PEXT_TRANS)
+	{
+		const char *client_string = Info_Get(&sv_client->_userinfo_ctx_, "*client");
+		char *ptr = strchr(client_string, ' ');
+		if (ptr != NULL) {
+			ptr++;
+			if (strncmp(client_string, "ezQuake", 7) == 0 && *ptr != '\0')
+			{
+				extern cvar_t sv_pext_ezquake_verfortrans;
+				char *endptr;
+				long revision = strtol(ptr, &endptr, 10);
+				if (*endptr != '\0' || (revision > 0 && revision < sv_pext_ezquake_verfortrans.value))
+				{
+					SV_ClientPrintf(sv_client, PRINT_HIGH, "\n\nWARNING:\n"
+						"Alpha support disabled due to buggy client, "
+						"if the map contains transparency you may be at a disadvantage.\n"
+						"Please upgrade to one of the following:\n"
+						"> ezQuake (https://www.ezquake.com)\n"
+						"> FTEQW (http://fte.triptohell.info/)\n");
+					sv_client->fteprotocolextensions &= ~FTE_PEXT_TRANS;
+				}
+			}
+		}
+	}
+#endif
+
 	//NOTE:  This doesn't go through ClientReliableWrite since it's before the user
 	//spawns.  These functions are written to not overflow
 	if (sv_client->num_backbuf)

--- a/src/vm_interpreted.c
+++ b/src/vm_interpreted.c
@@ -254,8 +254,7 @@ nextInstruction2:
 				//vm->programStack = programStack - 4;
 				vm->programStack = programStack - 8;
 				*(int *)&image[ programStack + 4 ] = ~r0.i;
-				{
-#if idx64 //__WORDSIZE == 64
+				if (sizeof(int) != sizeof(intptr_t)) {
 					// the vm has ints on the stack, we expect
 					// longs so we have to convert it
 					intptr_t argarr[16];
@@ -264,10 +263,9 @@ nextInstruction2:
 						argarr[ argn ] = *(int*)&image[ programStack + 4 + 4*argn ];
 					}
 					v0 = vm->systemCall( &argarr[0] );
-#else
+				} else {
                     //VM_LogSyscalls( (int *)&image[ programStack + 4 ] );
 					v0 = vm->systemCall( (intptr_t *)&image[ programStack + 4 ] );
-#endif
 				}
 
 				// save return value


### PR DESCRIPTION
FTE_PEXT_TRANS was broken when implemented long ago. This finishes the implementation, and also adds FTE_PEXT_COLOURMOD which was declared, but only implemented in renderer. The latter is a convenient extension field for mappers to use when dealing with alpha brushes later on. For example using the same glass texture with alpha, but tint it via colormod field.

Broken clients (all ezQ versions) will be demoted to opaque entities based on revision.

The renderer is only wired up to use the colourmod and alpha values, but is otherwise unchanged. Even if it has sorting already to blend transparent faces in a somewhat ok order, there are a number of bugs that may for example skip drawing entities behind a transparent entity. This will be dealt with in a later PR that also adds alpha brush support.

When no entity has modified alpha or colormod, the additional bytes are not written. The PF_EXTRA_PFS will however still write one extra byte due to the moving of PF_ONGROUND and PF_SOLID. This is only a problem for buggy clients that have cl_pext_alpha set to 1, and somehow trick the server side check that would disable it if the client is too old, ie you get what you ask for. 

For not fully connected usecases mvd and outdated qtv clients should remain unaffected by this change as long as no alpha nor colormod is used as it doesn't follow the networked player info packet structure. If for example using translucent spawn markers, these are only shown before demo recording usually begins so demos on maps without alpha entities will be playable in any old client. 