### PR TITLE
CMAKE: Switch OpenGL detection to legacy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,11 @@ else()
 endif()
 
 find_library(MATH m)
+
+# Override by configuring with -DOpenGL_GL_PREFERENCE=GLVND
+if(NOT OpenGL_GL_PREFERENCE)
+    set(OpenGL_GL_PREFERENCE LEGACY)
+endif()
 find_package(OpenGL REQUIRED)
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
This causes the executable to linked with libGL etc instead of libOpenGL etc. This only changes the behavior on *nix sytems.