### PR TITLE
CLIENT: Reset RF_FORCECOLOURMOD if unmodified.

### DIFF
--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -1067,6 +1067,10 @@ void CL_LinkPacketEntities(void)
 			ent.r_modelcolor[2] = ((float) state->colourmod[2] * 8.0f) / 256.0f;
 			ent.renderfx |= RF_FORCECOLOURMOD;
 		}
+		else
+		{
+			ent.renderfx &= ~RF_FORCECOLOURMOD;
+		}
 #endif
 
 		if (ent.model->flags & EF_ROTATE)


### PR DESCRIPTION
Same entity variable is reused during iteration. If not reset when unmodified, other entities will be tainted.