### PR TITLE
RENDERER: Add support for skywind.

### DIFF
--- a/help_commands.json
+++ b/help_commands.json
@@ -1659,6 +1659,24 @@
     "description": "In basics works same as mapgroup.",
     "syntax": "skyboxname map1 [map2] ..."
   },
+  "skywind": {
+    "description": "Sets the animation parameters of the skybox. Requires a skybox with some level of transparency.",
+    "syntax": "skywind [distance] [yaw] [period] [pitch]"
+  },
+  "skywind_save": {
+    "description": "Saves the current skywind configuration as gfx/env/$skybox_wind.cfg."
+  },
+  "skywind_load": {
+    "description": "Loads the skywind config for the loaded skymap. The file is expected to contain: skywind [distance] [yaw] [period] [pitch]."
+  },
+  "skywind_lookdir": {
+    "description": "Updates the skywind direction to current point of view with optional overrides of period and distance.",
+    "syntax": "skywind_lookdir [period] [distance]"
+  },
+  "skywind_rotate": {
+    "description": "Updates the skywind direction with yaw (horizontal) and pitch (vertical) adjustment.",
+    "syntax": "skywind_rotate [yaw] [pitch]"
+  },
   "snap": {
     "description": "Remote screenshot from a player.\n\nExample:\nsnap 1234\n - server requests remote screenshot from user 1234",
     "syntax": "<userid>"

--- a/help_variables.json
+++ b/help_variables.json
@@ -16590,6 +16590,13 @@
       "remarks": "Specifying a value will disable loading of skyboxes specified by the map.\nSkyboxes should be placed in 'env' or 'gfx/env' folders",
       "type": "string"
     },
+    "r_skywind": {
+      "default": "1",
+      "desc": "Sets the scale factor of skybox animation if above 0, and skybox has an animation configuration.",
+      "group-id": "51",
+      "remarks": "Specifying a value above 1.0 will increase the pace of the configured animation.",
+      "type": "float"
+    },
     "r_slimecolor": {
       "default": "10 60 10",
       "desc": "Changes color of slime when r_fastturb set to 1.",

--- a/src/gl_program.c
+++ b/src/gl_program.c
@@ -218,6 +218,8 @@ static r_program_uniform_t program_uniforms[] = {
 	{ r_program_sky_glc, "skySpeedscale2", 1, false },
 	// r_program_uniform_sky_glc_skyTex,
 	{ r_program_sky_glc, "skyTex", 1, false },
+	// r_program_uniform_sky_glc_skyWind,
+	{ r_program_sky_glc, "skyWind", 1, false },
 	// r_program_uniform_sky_glc_skyDomeTex,
 	{ r_program_sky_glc, "skyDomeTex", 1, false },
 	// r_program_uniform_sky_glc_skyDomeCloudTex,

--- a/src/glm_local.h
+++ b/src/glm_local.h
@@ -38,6 +38,10 @@ typedef struct uniform_block_frame_constants_s {
 	float r_farclip_unused;                  // NO LONGER USED, replace
 	float waterAlpha;
 
+	// animated skybox
+	vec3_t windDir;
+	float  windPhase;
+
 	// drawflat toggles (combine into bitfield?)
 	int r_drawflat;
 	int r_fastturb;

--- a/src/glm_misc.c
+++ b/src/glm_misc.c
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "glm_local.h"
 #include "r_renderer.h"
 #include "gl_texture.h"
+#include "r_brushmodel_sky.h"
 
 static uniform_block_frame_constants_t frameConstants;
 static qbool frameConstantsUploaded = false;
@@ -161,6 +162,8 @@ void GLM_PreRenderView(void)
 	frameConstants.fogMaxZ = r_refdef2.fog_linear_end;
 	frameConstants.skyFogMix = r_refdef2.fog_sky;
 	frameConstants.fogDensity = r_refdef2.fog_density; // (r_refdef2.fog_calculation == fogcalc_exp2 ? r_refdef2.fog_density * r_refdef2.fog_density : r_refdef2.fog_density);
+
+	Skywind_GetDirectionAndPhase(frameConstants.windDir, &frameConstants.windPhase);
 
 	frameConstantsUploaded = false;
 }

--- a/src/glm_rsurf.c
+++ b/src/glm_rsurf.c
@@ -112,6 +112,7 @@ static void GLM_CheckDrawCallSize(void)
 #define DRAW_DRAWFLAT_TINTED       (1 << 11)
 #define DRAW_DRAWFLAT_BRIGHT       (1 << 12)
 #define DRAW_ALPHATESTED           (1 << 13)
+#define DRAW_SKYWIND               (1 << 14)
 
 static int material_samplers_max;
 static int TEXTURE_UNIT_MATERIAL; // Must always be the first non-standard texture unit
@@ -134,6 +135,7 @@ static qbool GLM_CompileDrawWorldProgramImpl(r_program_id program_id, qbool alph
 	qbool luma_textures = gl_lumatextures.integer && r_refdef2.allow_lumas;
 	qbool skybox = r_skyboxloaded && !r_fastsky.integer;
 	qbool skydome = !skybox && !r_fastsky.integer && R_TextureReferenceIsValid(solidskytexture);
+	qbool skywind = skybox && Skywind_Active();
 
 	int drawworld_desiredOptions =
 		(detail_textures ? DRAW_DETAIL_TEXTURES : 0) |
@@ -148,7 +150,8 @@ static qbool GLM_CompileDrawWorldProgramImpl(r_program_id program_id, qbool alph
 		(r_drawflat.integer == 1 || r_drawflat.integer == 3 ? DRAW_FLATWALLS : 0) |
 		(gl_textureless.integer ? DRAW_TEXTURELESS : 0) |
 		((gl_outline.integer & 2) ? DRAW_GEOMETRY : 0) |
-		(alpha_test ? DRAW_ALPHATESTED : 0);
+		(alpha_test ? DRAW_ALPHATESTED : 0) |
+		(skywind ? DRAW_SKYWIND : 0);
 
 	if (R_ProgramRecompileNeeded(program_id, drawworld_desiredOptions)) {
 		static char included_definitions[2048];
@@ -192,7 +195,11 @@ static qbool GLM_CompileDrawWorldProgramImpl(r_program_id program_id, qbool alph
 			TEXTURE_UNIT_SKYBOX = samplers++;
 
 			strlcat(included_definitions, "#define DRAW_SKYBOX\n", sizeof(included_definitions));
+			if (skywind) {
+				strlcat(included_definitions, "#define DRAW_SKYWIND\n", sizeof(included_definitions));
+			}
 			strlcat(included_definitions, va("#define SAMPLER_SKYBOX_TEXTURE %d\n", TEXTURE_UNIT_SKYBOX), sizeof(included_definitions));
+
 		}
 		else if (skydome) {
 			TEXTURE_UNIT_SKYDOME_TEXTURE = samplers++;

--- a/src/glsl/common.glsl
+++ b/src/glsl/common.glsl
@@ -34,6 +34,9 @@ layout(std140, binding=EZQ_GL_BINDINGPOINT_FRAMECONSTANTS) uniform GlobalState {
 	float r_farclip_unused;              // Replace
 	float waterAlpha;
 
+	// animated skybox
+	vec4  skyWind;
+
 	// drawflat toggles
 	int r_drawflat;
 	int r_fastturb;

--- a/src/glsl/draw_world.fragment.glsl
+++ b/src/glsl/draw_world.fragment.glsl
@@ -10,7 +10,7 @@ layout(binding=SAMPLER_DETAIL_TEXTURE) uniform sampler2D detailTex;
 #ifdef DRAW_CAUSTIC_TEXTURES
 layout(binding=SAMPLER_CAUSTIC_TEXTURE) uniform sampler2D causticsTex;
 #endif
-#ifdef DRAW_SKYBOX
+#if defined(DRAW_SKYBOX)
 layout(binding=SAMPLER_SKYBOX_TEXTURE) uniform samplerCube skyTex;
 #elif defined(DRAW_SKYDOME)
 layout(binding=SAMPLER_SKYDOME_TEXTURE) uniform sampler2D skyDomeTex;
@@ -169,6 +169,20 @@ void main()
 		else if (turbType == TEXTURE_TURB_SKY) {
 #if defined(DRAW_SKYBOX)
 			frag_colour = texture(skyTex, Direction);
+#if defined(DRAW_SKYWIND)
+			float t1 = skyWind.w;
+			float t2 = fract(t1) - 0.5;
+			float blend = abs(t1 * 2.0);
+			vec3 dir = normalize(Direction);
+			vec4 layer1 = texture(skyTex, dir + t1 * skyWind.xyz);
+			vec4 layer2 = texture(skyTex, dir + t2 * skyWind.xyz);
+			layer1.a *= 1.0 - blend;
+			layer2.a *= blend;
+			layer1.rgb *= layer1.a;
+			layer2.rgb *= layer2.a;
+			vec4 combined = layer1 + layer2;
+			frag_colour = vec4(frag_colour.rgb * (1.0 - combined.a) + combined.rgb, 1);
+#endif
 #elif defined(DRAW_SKYDOME)
 			const float len = 3.09375;
 			// Flatten it out

--- a/src/glsl/glc/glc_sky.fragment.glsl
+++ b/src/glsl/glc/glc_sky.fragment.glsl
@@ -4,6 +4,9 @@
 
 #ifdef DRAW_SKYBOX
 uniform samplerCube skyTex;
+#ifdef DRAW_SKYWIND
+uniform vec4 skyWind;
+#endif
 #else
 uniform sampler2D skyDomeTex;
 uniform sampler2D skyDomeCloudTex;
@@ -22,6 +25,20 @@ void main()
 {
 #if defined(DRAW_SKYBOX)
 	gl_FragColor = textureCube(skyTex, Direction);
+#if defined(DRAW_SKYWIND)
+	float t1 = skyWind.w;
+	float t2 = fract(t1) - 0.5;
+	float blend = abs(t1 * 2.0);
+	vec3 dir = normalize(Direction);
+	vec4 layer1 = textureCube(skyTex, dir + t1 * skyWind.xyz);
+	vec4 layer2 = textureCube(skyTex, dir + t2 * skyWind.xyz);
+	layer1.a *= 1.0 - blend;
+	layer2.a *= blend;
+	layer1.rgb *= layer1.a;
+	layer2.rgb *= layer2.a;
+	vec4 combined = layer1 + layer2;
+	gl_FragColor = vec4(gl_FragColor.rgb * (1.0 - combined.a) + combined.rgb, 1);
+#endif
 #else
 	const float len = 3.09375;
 	// Flatten it out

--- a/src/r_brushmodel_sky.h
+++ b/src/r_brushmodel_sky.h
@@ -13,7 +13,10 @@ extern cvar_t r_skyname;
 extern texture_ref skyboxtextures[MAX_SKYBOXTEXTURES];
 
 void R_ClearSkyTextures(void);
-void R_LoadSky_f(void);
+void R_SkyRegisterCvars(void);
 extern qbool r_skyboxloaded;
+
+qbool Skywind_Active(void);
+qbool Skywind_GetDirectionAndPhase(float wind_dir[3], float *wind_phase);
 
 #endif // EZQUAKE_R_BRUSHMODEL_SKY_HEADER

--- a/src/r_program.h
+++ b/src/r_program.h
@@ -54,6 +54,7 @@ typedef enum {
 	r_program_uniform_sky_glc_speedscale,
 	r_program_uniform_sky_glc_speedscale2,
 	r_program_uniform_sky_glc_skyTex,
+	r_program_uniform_sky_glc_skyWind,
 	r_program_uniform_sky_glc_skyDomeTex,
 	r_program_uniform_sky_glc_skyDomeCloudTex,
 	r_program_uniform_turb_glc_texSampler,

--- a/src/r_rmain.c
+++ b/src/r_rmain.c
@@ -169,6 +169,7 @@ cvar_t r_floorcolor                        = {"r_floorcolor", "50 100 150", CVAR
 cvar_t gl_textureless                      = {"gl_textureless", "0", 0, OnChange_r_drawflat}; //Qrack
 cvar_t r_farclip                           = {"r_farclip", "8192", CVAR_RULESET_MAX | CVAR_RULESET_MIN, NULL, 8192.0f, R_MAXIMUM_FARCLIP, R_MINIMUM_FARCLIP }; // previous default was 4096. 8192 helps some TF players in big maps
 cvar_t r_skyname                           = {"r_skyname", "", 0, OnChange_r_skyname};
+cvar_t r_skywind                           = {"r_skywind", "1"};
 cvar_t gl_detail                           = {"gl_detail","0"};
 cvar_t gl_brush_polygonoffset              = {"gl_brush_polygonoffset", "2.0"}; // This is the one to adjust if you notice flicker on lift @ e1m1 for instance, for z-fighting
 cvar_t gl_brush_polygonoffset_factor       = {"gl_brush_polygonoffset_factor", "0.05"};
@@ -602,7 +603,7 @@ static void R_SetupGL(void)
 
 void R_Init(void)
 {
-	Cmd_AddCommand("loadsky", R_LoadSky_f);
+	R_SkyRegisterCvars();
 	Cmd_AddCommand("timerefresh", R_TimeRefresh_f);
 #ifndef CLIENTONLY
 	Cmd_AddCommand("dev_pointfile", R_ReadPointFile_f);
@@ -654,6 +655,7 @@ void R_Init(void)
 
 	Cvar_SetCurrentGroup(CVAR_GROUP_TURB);
 	Cvar_Register(&r_skyname);
+	Cvar_Register(&r_skywind);
 	Cvar_Register(&r_fastsky);
 	Cvar_Register(&r_skycolor);
 	Cvar_Register(&r_fastturb);


### PR DESCRIPTION
Feature available in the SP community. Ported mostly verbatim from the IronWail engine. Partial cubemap alpha which gets blended with itself to create the illusion of a moving sky. Quite hypnotizing.

To simplify tuning of the skybox the following commands are included in the port:

* /skywind
* /skywind_save
* /skywind_load
* /skywind_lookdir
* /skywind_rotate

If a config file named $skyboxname_wind.cfg in the same directory as the skybox is found, it's automatically loaded and configures the sky.

Implemented for both modern and classic renderers.