### PR TITLE
Add remote capabilities validation

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1037,6 +1037,12 @@
         }
       ]
     },
+    "cl_allow_downloads": {
+      "default": "bsp,lmp,loc,mdl,mvd,pcx,spr,wad,wav",
+      "desc": "This variable controls which file extensions a client/server can download/upload from/to the server/client.",
+      "group-id": "9",
+      "type": "string"
+    },
     "cl_anglespeedkey": {
       "default": "1.5",
       "desc": "This variable sets multiplier by which your \"cl_yawspeed\" (how fast you turn) is multiplied when running (+speed).",

--- a/help_variables.json
+++ b/help_variables.json
@@ -2500,6 +2500,12 @@
         }
       ]
     },
+    "cl_remote_capabilities": {
+      "default": "alias,bf,changing,cmd,color,download,exec,fullserverinfo,impulse,infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter,on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf,on_spec_enter_ffa,packet,play,reconnect,say,sinfoset,skin,skins,team,tempalias,track,wait",
+      "desc": "This variable controls which commands and variables a server is allowed to execute or set on the client. Input a comma-separated list of commands and variables to toggle access. The default values are adapted for KTX use.",
+      "group-id": "9",
+      "type": "string"
+    },
     "cl_restrictions": {
       "default": "0",
       "desc": "Triggers and re/msg trigger restrictions for spectator and demoplay modes.",

--- a/help_variables.json
+++ b/help_variables.json
@@ -1043,6 +1043,21 @@
       "group-id": "9",
       "type": "string"
     },
+    "cl_allow_uploads": {
+      "default": "0",
+      "group-id": "9",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Don't allow uploads.",
+          "name": "0"
+        },
+        {
+          "description": "Allow uploads.",
+          "name": "1"
+        }
+      ]
+    },
     "cl_anglespeedkey": {
       "default": "1.5",
       "desc": "This variable sets multiplier by which your \"cl_yawspeed\" (how fast you turn) is multiplied when running (+speed).",

--- a/src/cl_cmd.c
+++ b/src/cl_cmd.c
@@ -626,14 +626,30 @@ void CL_Rcon_f (void) {
 
 qbool CL_Download_Accept(const char *filename)
 {
+	char *str, *tmp, *ext;
+	qbool is_valid = false;
+	extern cvar_t cl_allow_downloads;
+
 	if (strstr(filename, "..") || !strcmp(filename, "") || filename[0] == '/' || strchr(filename, '\\') || strchr(filename, ':') || strstr(filename, "//")) {
 		Com_Printf("Warning: Invalid characters in filename \"%s\"\n", filename);
 		return false;
 	}
 
-	const char *tmp = strrchr(filename, '.');
-	if (tmp != NULL && (!strcasecmp(tmp, ".dll") || !strcasecmp(tmp, ".so"))) {
-		Com_Printf("Warning: Non-allowed file \"%s\" skipped\n", filename);
+	ext = COM_FileExtension(filename);
+	str = Q_strdup(cl_allow_downloads.string);
+	tmp = strtok(str, ",");
+	while (tmp != NULL) {
+		if (strcmp(ext, tmp) == 0) {
+			is_valid = true;
+			break;
+		}
+
+		tmp = strtok(NULL, ",");
+	}
+	Q_free(str);
+
+	if (!is_valid) {
+		Com_Printf("Warning: Non-allowed file \"%s\" skipped. Add \"%s\" to cl_allow_download_file_extensions to allow the file to be downloaded\n", filename, ext);
 		return false;
 	}
 

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -1287,7 +1287,13 @@ void CL_StartFileUpload (void)
 {
 	char *name;
 	int i;
+	extern cvar_t cl_allow_uploads;
 
+	if (!cl_allow_uploads.integer)
+	{
+		Com_Printf ("This command has been disabled for security reasons. Set cl_allow_uploads to 1 if you want to enable uploads.\n");
+		return;
+	}
 
 	if (cls.state < ca_onserver) 
 	{

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -69,6 +69,7 @@ cvar_t cl_remote_capabilities = {"cl_remote_capabilities", REMOTE_CAPABILITIES, 
 hashtable_t *rc_hash;
 
 cvar_t cl_allow_downloads = {"cl_allow_downloads", "bsp,lmp,loc,mdl,mvd,pcx,spr,wad,wav"};
+cvar_t cl_allow_uploads = {"cl_allow_uploads", "0"};
 
 cbuf_t cbuf_main;
 cbuf_t cbuf_svc;
@@ -2496,6 +2497,7 @@ void Cmd_Init (void)
 	Cvar_Register(&cl_warnexec);
 	Cvar_Register(&cl_remote_capabilities);
 	Cvar_Register(&cl_allow_downloads);
+	Cvar_Register(&cl_allow_uploads);
 
 	Cmd_AddCommand ("macrolist", Cmd_MacroList_f);
 	qsort(msgtrigger_commands,

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -68,6 +68,8 @@ cvar_t cl_remote_capabilities = {"cl_remote_capabilities", REMOTE_CAPABILITIES, 
 				   OnChange_remote_capabilities};
 hashtable_t *rc_hash;
 
+cvar_t cl_allow_downloads = {"cl_allow_downloads", "bsp,lmp,loc,mdl,mvd,pcx,spr,wad,wav"};
+
 cbuf_t cbuf_main;
 cbuf_t cbuf_svc;
 cbuf_t cbuf_safe, cbuf_formatted_comms;
@@ -2493,6 +2495,7 @@ void Cmd_Init (void)
 	Cvar_Register(&cl_curlybraces);
 	Cvar_Register(&cl_warnexec);
 	Cvar_Register(&cl_remote_capabilities);
+	Cvar_Register(&cl_allow_downloads);
 
 	Cmd_AddCommand ("macrolist", Cmd_MacroList_f);
 	qsort(msgtrigger_commands,


### PR DESCRIPTION
This PR addresses the RCE issue that I discovered earlier this year. It consists of three new cvars:

- `cl_remote_capabilities`, controls which commands and variables the server is allowed to execute or set on the client. The default values used here should be compatible with KTX use.
- `cl_allow_downloads`, allows the user to control which file extensions a client/server can download/upload from/to the server/client.
- `cl_allow_uploads`, toggles whether or not the upload function is enabled. This prevents the server from downloading files from the client's computer.