### PR TITLE
Allow server to stufftext {+,-}attack

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -2522,7 +2522,7 @@
       ]
     },
     "cl_remote_capabilities": {
-      "default": "alias,bf,changing,cmd,color,download,exec,fullserverinfo,impulse,infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter,on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf,on_spec_enter_ffa,packet,play,reconnect,say,sinfoset,skin,skins,team,tempalias,track,wait",
+      "default": "alias,bf,changing,cmd,color,download,exec,fullserverinfo,impulse,infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter,on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf,on_spec_enter_ffa,packet,play,reconnect,say,sinfoset,skin,skins,team,tempalias,track,wait,+attack,-attack",
       "desc": "This variable controls which commands and variables a server is allowed to execute or set on the client. Input a comma-separated list of commands and variables to toggle access. The default values are adapted for KTX use.",
       "group-id": "9",
       "type": "string"

--- a/help_variables.json
+++ b/help_variables.json
@@ -2522,7 +2522,7 @@
       ]
     },
     "cl_remote_capabilities": {
-      "default": "alias,bf,changing,cmd,color,download,exec,fullserverinfo,impulse,infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter,on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf,on_spec_enter_ffa,packet,play,reconnect,say,sinfoset,skin,skins,team,tempalias,track,wait,+attack,-attack",
+      "default": "alias,bf,changing,cmd,color,download,exec,fullserverinfo,impulse,infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter,on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf,on_spec_enter_ffa,packet,play,rate,reconnect,say,sinfoset,skin,skins,team,tempalias,track,wait,+attack,-attack",
       "desc": "This variable controls which commands and variables a server is allowed to execute or set on the client. Input a comma-separated list of commands and variables to toggle access. The default values are adapted for KTX use.",
       "group-id": "9",
       "type": "string"

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -62,7 +62,7 @@ cvar_t cl_curlybraces = {"cl_curlybraces", "0"};
 				"infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter," \
 				"on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf," \
 				"on_spec_enter_ffa,packet,play,reconnect,say,sinfoset,skin," \
-				"skins,team,tempalias,track,wait"
+				"skins,team,tempalias,track,wait,+attack,-attack"
 static void OnChange_remote_capabilities(cvar_t *var, char *string, qbool *cancel);
 cvar_t cl_remote_capabilities = {"cl_remote_capabilities", REMOTE_CAPABILITIES, 0,
 				   OnChange_remote_capabilities};

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -61,7 +61,7 @@ cvar_t cl_curlybraces = {"cl_curlybraces", "0"};
 #define REMOTE_CAPABILITIES "alias,bf,changing,cmd,color,download,exec,fullserverinfo,impulse," \
 				"infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter," \
 				"on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf," \
-				"on_spec_enter_ffa,packet,play,reconnect,say,sinfoset,skin," \
+				"on_spec_enter_ffa,packet,play,rate,reconnect,say,sinfoset,skin," \
 				"skins,team,tempalias,track,wait,+attack,-attack"
 static void OnChange_remote_capabilities(cvar_t *var, char *string, qbool *cancel);
 cvar_t cl_remote_capabilities = {"cl_remote_capabilities", REMOTE_CAPABILITIES, 0,


### PR DESCRIPTION
When using wreg and spectating on a KTX server, {+,-}attack commands are issued when firing.

See: https://github.com/QW-Group/ktx/blob/master/src/commands.c#L7246-L7263