### PR TITLE
UI: Fix memleak in version check.

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -229,9 +229,14 @@ static int VersionCheck_Thread(void *args)
 
 cleanup:
 	if (root != NULL)
+	{
 		json_decref(root);
+	}
 	if (curl != NULL)
+	{
+		curl_slist_free_all(headers);
 		curl_easy_cleanup(curl);
+	}
 
 	SDL_LockMutex(version_mutex);
 	version_refreshing = false;


### PR DESCRIPTION
Once per lifetime leak, but headers should ofc be freed.