### PR TITLE
CONSOLE: Fix buffer overflow.

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -997,9 +997,9 @@ void Con_DrawConsole (int lines) {
 
 		i = strlen (dlbar);
 		if (cls.download)
-			snprintf (dlbar + i, sizeof (dlbar), " %02d%%(%dkb/s)", cls.downloadpercent, cls.downloadrate);
+			snprintf (dlbar + i, sizeof (dlbar) - i, " %02d%%(%dkb/s)", cls.downloadpercent, cls.downloadrate);
 		else if (cls.upload)
-			snprintf (dlbar + i, sizeof (dlbar), " %02d%%(%dkb/s)", cls.uploadpercent, cls.uploadrate);
+			snprintf (dlbar + i, sizeof (dlbar) - i, " %02d%%(%dkb/s)", cls.uploadpercent, cls.uploadrate);
 		else
 			return;
 


### PR DESCRIPTION
snprintf implementation may decide to write at the end of the specified buffer length for security reasons which will produce a crash even if the conditions happen to be within bounds.