### PR TITLE
PROTOCOL,DEMO: Strictness and correctness.

### DIFF
--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -1590,7 +1590,29 @@ guess_pm_type:
 			// Write out here - generally packets are copied, but flags for userdelta were changed
 			//   in protocol 27 - we always write out in new format
 			MSG_WriteByte(&cls.demomessage, num);
+#if defined(FTE_PEXT_TRANS)
+			if (cls.fteprotocolextensions & FTE_PEXT_TRANS)
+			{
+				if (flags & 0xff0000)
+				{
+					flags |= PF_EXTRA_PFS;
+				}
+				MSG_WriteShort (&cls.demomessage, flags & 0xffff);
+				if (flags & PF_EXTRA_PFS)
+				{
+					MSG_WriteByte(&cls.demomessage, (flags & 0xff0000) >> 16);
+				}
+			}
+			else
+			{
+				// Without PEXT_TRANS there's no PF_EXTRA_PFS, move
+				// PF_ONGROUND and PF_SOLID to their expected offsets.
+				MSG_WriteShort (&cls.demomessage, flags & 0x3fff | (flags & 0xc00000) >> 8);
+			}
+#else
 			MSG_WriteShort(&cls.demomessage, flags);
+#endif
+
 			if (cls.mvdprotocolextensions1 & MVD_PEXT1_FLOATCOORDS) {
 				MSG_WriteLongCoord(&cls.demomessage, state->origin[0]);
 				MSG_WriteLongCoord(&cls.demomessage, state->origin[1]);

--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -1525,14 +1525,6 @@ void CL_ParsePlayerinfo (void)
 		if (flags & PF_TRANS_Z && cls.fteprotocolextensions & FTE_PEXT_TRANS)
 			state->alpha = MSG_ReadByte();
 #endif
-#ifdef FTE_PEXT_COLOURMOD
-		if (flags & PF_COLOURMOD && cls.fteprotocolextensions & FTE_PEXT_COLOURMOD)
-		{
-			state->colourmod[0] = MSG_ReadByte();
-			state->colourmod[1] = MSG_ReadByte();
-			state->colourmod[2] = MSG_ReadByte();
-		}
-#endif
 
 		if (cl.z_ext & Z_EXT_PM_TYPE)
 		{

--- a/src/com_msg.c
+++ b/src/com_msg.c
@@ -352,6 +352,22 @@ void MSG_WriteDeltaEntity (entity_state_t *from, entity_state_t *to, sizebuf_t *
 		}
 	}
 
+#ifdef U_FTE_TRANS
+	if (to->trans != from->trans && (fte_extensions & FTE_PEXT_TRANS)) {
+		evenmorebits |= U_FTE_TRANS;
+		required_extensions |= FTE_PEXT_TRANS;
+    }
+#endif
+
+#ifdef U_FTE_COLOURMOD
+	if ((to->colourmod[0] != from->colourmod[0] ||
+		 to->colourmod[1] != from->colourmod[1] ||
+		 to->colourmod[2] != from->colourmod[2]) && (fte_extensions & FTE_PEXT_COLOURMOD)) {
+		evenmorebits |= U_FTE_COLOURMOD;
+		required_extensions |= FTE_PEXT_COLOURMOD;
+    }
+#endif
+
 	if (evenmorebits&0xff00)
 		evenmorebits |= U_FTE_YETMORE;
 	if (evenmorebits&0x00ff)
@@ -430,6 +446,20 @@ void MSG_WriteDeltaEntity (entity_state_t *from, entity_state_t *to, sizebuf_t *
 	}
 	if (bits & U_ANGLE3)
 		MSG_WriteAngle(msg, to->angles[2]);
+
+#ifdef U_FTE_TRANS
+	if (evenmorebits & U_FTE_TRANS)
+		MSG_WriteByte (msg, to->trans);
+#endif
+
+#ifdef U_FTE_COLOURMOD
+	if (evenmorebits & U_FTE_COLOURMOD)
+	{
+		MSG_WriteByte (msg, to->colourmod[0]);
+		MSG_WriteByte (msg, to->colourmod[1]);
+		MSG_WriteByte (msg, to->colourmod[2]);
+	}
+#endif
 }
 
 /********************************** READING **********************************/

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -644,14 +644,6 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 			pflags |= PF_TRANS_Z;
 		}
 #endif
-#ifdef FTE_PEXT_COLOURMOD
-		if (client->fteprotocolextensions & FTE_PEXT_COLOURMOD &&
-		    (ent->xv.colourmod[0] > 0.0f && ent->xv.colourmod[1] > 0.0f && ent->xv.colourmod[2] > 0.0f) &&
-		    !(ent->xv.colourmod[0] == 1.0f && ent->xv.colourmod[1] == 1.0f && ent->xv.colourmod[2] == 1.0f))
-		{
-			pflags |= PF_COLOURMOD;
-		}
-#endif
 
 		// Z_EXT_PM_TYPE protocol extension
 		// encode pm_type and jump_held into pm_code
@@ -704,8 +696,8 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		MSG_WriteByte (msg, svc_playerinfo);
 		MSG_WriteByte (msg, j);
 
-#if defined(FTE_PEXT_TRANS) && defined(FTE_PEXT_COLOURMOD)
-		if (client->fteprotocolextensions & (FTE_PEXT_TRANS | FTE_PEXT_COLOURMOD))
+#if defined(FTE_PEXT_TRANS)
+		if (client->fteprotocolextensions & FTE_PEXT_TRANS)
 		{
 			if (pflags & 0xff0000)
 			{
@@ -798,14 +790,6 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		if (pflags & PF_TRANS_Z)
 		{
 			MSG_WriteByte (msg, bound(1, (byte)(ent->xv.alpha * 254.0f), 254));
-		}
-#endif
-#ifdef FTE_PEXT_COLOURMOD
-		if (pflags & PF_COLOURMOD)
-		{
-			MSG_WriteByte(msg, bound(0, ent->xv.colourmod[0] * (256.0f / 8.0f), 255));
-			MSG_WriteByte(msg, bound(0, ent->xv.colourmod[1] * (256.0f / 8.0f), 255));
-			MSG_WriteByte(msg, bound(0, ent->xv.colourmod[2] * (256.0f / 8.0f), 255));
 		}
 #endif
 	}

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -211,15 +211,19 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 	}
 
 #ifdef U_FTE_TRANS
-    if (to->trans != from->trans && (fte_extensions & FTE_PEXT_TRANS))
-        evenmorebits |= U_FTE_TRANS;
+	if (to->trans != from->trans && (fte_extensions & FTE_PEXT_TRANS)) {
+		evenmorebits |= U_FTE_TRANS;
+		required_extensions |= FTE_PEXT_TRANS;
+	}
 #endif
 
 #ifdef U_FTE_COLOURMOD
 	if ((to->colourmod[0] != from->colourmod[0] ||
 	     to->colourmod[1] != from->colourmod[1] ||
-	     to->colourmod[2] != from->colourmod[2]) && (fte_extensions & FTE_PEXT_COLOURMOD))
+	     to->colourmod[2] != from->colourmod[2]) && (fte_extensions & FTE_PEXT_COLOURMOD)) {
 		evenmorebits |= U_FTE_COLOURMOD;
+		required_extensions |= FTE_PEXT_COLOURMOD;
+	}
 #endif
 
 	if (evenmorebits&0xff00)


### PR DESCRIPTION
* Incorrectly wrote colourmod to playerinfo.
* Stricter extension checking for alpha/colourmod.
* Write PF_EXTRA_PFS for demo if PEXTs not disabled.
* Write alpha/colourmod delta updates.

As CL_WriteStartupData completely ignores cl_pext=1 svc_fte_spawnbaseline2 & svc_fte_spawnstatic2 are not written, so recording mid game will not write already set extended attributes yet.