### PR TITLE
FOV: fix rare CalcFov+viewsize glitches

### DIFF
--- a/src/cl_screen.c
+++ b/src/cl_screen.c
@@ -232,8 +232,18 @@ static void CalcFov(float fov, float *fov_x, float *fov_y, float width, float he
 
 	if (width / 4 < height / 3) {
 		fovx = fov;
-		t = width / tan(fovx / 360 * M_PI);
-		fovy = atan (height / t) * 360 / M_PI;
+
+		if (reduce_vertfov) {
+			// Crop vertically when viewsize decreased
+			// hmx: Fixes "legacy" fov style causing some visual glitches since 3.0.1 in rare aspect ratios/viewsizes combos
+			// *almost* matches 3.0 results *and* not visually broken
+			t = view_width / tan(fovx / 360 * M_PI);
+			fovy = atan(view_height / t) * 360 / M_PI;
+		}
+		else {
+			t = width / tan(fovx / 360 * M_PI);
+			fovy = atan(height / t) * 360 / M_PI;
+		}
 	}
 	else {
 		fovx = fov;


### PR DESCRIPTION
3.0 added more math to mostly classic, GLQWCL CalcFov to try and derive FOV from a reference 4:3 ratio.
This accomodated everything above 4:3, which was becoming the norm at the time.
3.0.1 also added a letterbox option which somewhat "maintains" FOV for `viewsize < 100` - for ratios 4:3+.

Viewport size is not always strictly proportional to the vid size, due to the varying margins that are added - i.e, the aspect ratios do not always match.
However, classic GLQWCL CalcFov always worked on viewport size, whether it was the screen size or not - so there was never a problem.

3.0.1+ passes the viewport size *and* the vid size and takes both into account for 4:3+, but still only works from vid size under 4:3.
Result: in some rare combinations at those narrow ratios, the viewport and screen ratios will go out of whack and Calcfov gives a horizontal fov too wide for the viewport (glitches!)

This patch adds the same 3.0.1 `height/width` vs `view_height/width` viewsize fix to the existing "anything under 4:3" clause.
Everything else remains unchanged.