### PR TITLE
LIGHTMAPS: Support for loading e5bgr9 lightmaps.

### DIFF
--- a/src/gl_model.h
+++ b/src/gl_model.h
@@ -465,6 +465,8 @@ typedef enum
 #define	EF_TRACER2	64			// orange split trail + rotate
 #define	EF_TRACER3	128			// purple trail
 
+#define MOD_HDRLIGHTING (1u<<13)	//spike -- light samples are in e5bgr9 format. int aligned.
+
 #define MAX_SIMPLE_TEXTURES 5
 #define MAX_TEXTURE_ARRAYS_PER_MODEL 64
 
@@ -542,6 +544,7 @@ typedef struct model_s {
 	byte*               visdata;
 	int                 visdata_length;
 	byte*               lightdata;
+	size_t              lightdatasamplesize;
 
 	int					bspversion;
 	qbool				isworldmodel;

--- a/src/r_lighting.h
+++ b/src/r_lighting.h
@@ -34,6 +34,14 @@ void R_RenderDlights(void);
 void R_LightEntity(entity_t* ent);
 
 extern unsigned int d_lightstylevalue[256];	// 8.8 fraction of base light value
+static const float rgb9e5tab[32] = {
+	//multipliers for the 9-bit mantissa, according to the biased mantissa
+	//aka: pow(2, biasedexponent - bias-bits) where bias is 15 and bits is 9
+	1.0/(1<<24), 1.0/(1<<23), 1.0/(1<<22), 1.0/(1<<21), 1.0/(1<<20), 1.0/(1<<19), 1.0/(1<<18), 1.0/(1<<17),
+	1.0/(1<<16), 1.0/(1<<15), 1.0/(1<<14), 1.0/(1<<13), 1.0/(1<<12), 1.0/(1<<11), 1.0/(1<<10), 1.0/(1<<9),
+	1.0/(1<<8),  1.0/(1<<7),  1.0/(1<<6),  1.0/(1<<5),  1.0/(1<<4),  1.0/(1<<3),  1.0/(1<<2),  1.0/(1<<1),
+	1.0,         1.0*(1<<1),  1.0*(1<<2),  1.0*(1<<3),  1.0*(1<<4),  1.0*(1<<5),  1.0*(1<<6),  1.0*(1<<7),
+};
 
 extern cvar_t r_dynamic;
 #define R_NoLighting()       (r_dynamic.integer == 0)

--- a/src/r_rlight.c
+++ b/src/r_rlight.c
@@ -321,20 +321,32 @@ static void R_LightFromSurface(msurface_t* surf, int ds, int dt, vec3_t color)
 {
 	if (surf->samples) {
 		// LordHavoc: enhanced to interpolate lighting
-		byte *lightmap;
 		int maps, line3, dsfrac = ds & 15, dtfrac = dt & 15, r00 = 0, g00 = 0, b00 = 0, r01 = 0, g01 = 0, b01 = 0, r10 = 0, g10 = 0, b10 = 0, r11 = 0, g11 = 0, b11 = 0;
 		float scale;
 		line3 = ((surf->extents[0] >> 4) + 1) * 3;
 
-		lightmap = surf->samples + ((dt >> 4) * ((surf->extents[0] >> 4) + 1) + (ds >> 4)) * 3; // LordHavoc: *3 for color
-
-		for (maps = 0; maps < MAXLIGHTMAPS && surf->styles[maps] != 255; maps++) {
-			scale = (float)d_lightstylevalue[surf->styles[maps]] * 1.0 / 256.0;
-			r00 += (float)lightmap[0] * scale; g00 += (float)lightmap[1] * scale; b00 += (float)lightmap[2] * scale;
-			r01 += (float)lightmap[3] * scale; g01 += (float)lightmap[4] * scale; b01 += (float)lightmap[5] * scale;
-			r10 += (float)lightmap[line3 + 0] * scale; g10 += (float)lightmap[line3 + 1] * scale; b10 += (float)lightmap[line3 + 2] * scale;
-			r11 += (float)lightmap[line3 + 3] * scale; g11 += (float)lightmap[line3 + 4] * scale; b11 += (float)lightmap[line3 + 5] * scale;
-			lightmap += ((surf->extents[0] >> 4) + 1) * ((surf->extents[1] >> 4) + 1) * 3; // LordHavoc: *3 for colored lighting
+		if (cl.worldmodel->flags & MOD_HDRLIGHTING) {
+			uint32_t *lightmap = (uint32_t*)surf->samples + (dt * (surf->extents[0]+1) + ds);
+			line3 = (surf->extents[0]+1);
+			for (maps = 0;maps < MAXLIGHTMAPS && surf->styles[maps] != 255; maps++) {
+				float e;
+				scale = (1<<7) * (float) d_lightstylevalue[surf->styles[maps]] * 1.0f / 256.0f;
+				e = rgb9e5tab[lightmap[      0]>>27] * scale;r00 += ((lightmap[      0]>> 0)&0x1ff) * e;g00 += ((lightmap[      0]>> 9)&0x1ff) * e;b00 += ((lightmap[      0]>> 9)&0x1ff) * e;
+				e = rgb9e5tab[lightmap[      1]>>27] * scale;r01 += ((lightmap[      1]>> 0)&0x1ff) * e;g01 += ((lightmap[      1]>> 9)&0x1ff) * e;b01 += ((lightmap[      1]>> 9)&0x1ff) * e;
+				e = rgb9e5tab[lightmap[line3+0]>>27] * scale;r10 += ((lightmap[line3+0]>> 0)&0x1ff) * e;g10 += ((lightmap[line3+0]>> 9)&0x1ff) * e;b10 += ((lightmap[line3+0]>> 9)&0x1ff) * e;
+				e = rgb9e5tab[lightmap[line3+1]>>27] * scale;r11 += ((lightmap[line3+1]>> 0)&0x1ff) * e;g11 += ((lightmap[line3+1]>> 9)&0x1ff) * e;b11 += ((lightmap[line3+1]>> 9)&0x1ff) * e;
+				lightmap += (surf->extents[0]+1) * (surf->extents[1]+1);
+			}
+		} else {
+			byte *lightmap = surf->samples + ((dt >> 4) * ((surf->extents[0] >> 4) + 1) + (ds >> 4)) * 3; // LordHavoc: *3 for color
+			for (maps = 0; maps < MAXLIGHTMAPS && surf->styles[maps] != 255; maps++) {
+				scale = (float)d_lightstylevalue[surf->styles[maps]] * 1.0 / 256.0;
+				r00 += (float)lightmap[0] * scale; g00 += (float)lightmap[1] * scale; b00 += (float)lightmap[2] * scale;
+				r01 += (float)lightmap[3] * scale; g01 += (float)lightmap[4] * scale; b01 += (float)lightmap[5] * scale;
+				r10 += (float)lightmap[line3 + 0] * scale; g10 += (float)lightmap[line3 + 1] * scale; b10 += (float)lightmap[line3 + 2] * scale;
+				r11 += (float)lightmap[line3 + 3] * scale; g11 += (float)lightmap[line3 + 4] * scale; b11 += (float)lightmap[line3 + 5] * scale;
+				lightmap += ((surf->extents[0] >> 4) + 1) * ((surf->extents[1] >> 4) + 1) * 3; // LordHavoc: *3 for colored lighting
+			}
 		}
 
 		color[0] += (float)((int)((((((((r11 - r10) * dsfrac) >> 4) + r10) - ((((r01 - r00) * dsfrac) >> 4) + r00)) * dtfrac) >> 4) + ((((r01 - r00) * dsfrac) >> 4) + r00)));


### PR DESCRIPTION
This format was added to ericw-tools spring 2024. Initial implementation does not expose it's full range potential, but it loads, and works, which gives mappers the option to target this format instead of the old rgb8 format.

Ported from QuakeSpasm-Spiked, also implemented in FTE.