### PR TITLE
ENTS: Partially revert "Skip clearing visents list".

### DIFF
--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -165,8 +165,11 @@ static qbool is_monster (int modelindex)
 	return false;
 }
 
-void CL_ClearScene(void)
-{
+void CL_ClearScene(void) {
+	if (cl_visents.count > 0)
+	{
+		memset(cl_visents.list, 0, sizeof(cl_visents.list[0]) * cl_visents.count);
+	}
 	memset(cl_visents.typecount, 0, sizeof(cl_visents.typecount));
 	cl_visents.count = 0;
 }


### PR DESCRIPTION
Clear visents that were in use, or fallback to all. Should be revisited at a later point in time. At least normally smaller memset than there used to be.