### PR TITLE
Add scr_scoreboard_showclock

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -19102,6 +19102,21 @@
         }
       ]
     },
+    "scr_scoreboard_showclock": {
+      "default": "0",
+      "group-id": "47",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Hide the clock on the scoreboard.",
+          "name": "false"
+        },
+        {
+          "description": "Show the clock on the scoreboard.",
+          "name": "true"
+        }
+      ]
+    },
     "scr_scoreboard_showfrags": {
       "default": "1",
       "group-id": "47",

--- a/src/sbar.c
+++ b/src/sbar.c
@@ -143,6 +143,7 @@ cvar_t  scr_scoreboard_proportional   = {"scr_scoreboard_proportional",   "0"};
 cvar_t  scr_scoreboard_wipeout	 	  = {"scr_scoreboard_wipeout",   	  "1"};
 cvar_t	scr_scoreboard_classic        = {"scr_scoreboard_classic", "0"};
 cvar_t	scr_scoreboard_highlightself  = {"scr_scoreboard_highlightself", "1"};
+cvar_t	scr_scoreboard_showclock      = {"scr_scoreboard_showclock", "0"};
 
 // VFrags: only draw the frags for the first player when using mvinset
 #define MULTIVIEWTHISPOV() ((!cl_multiview.value) || (cl_mvinset.value && CL_MultiviewCurrentView() == 1))
@@ -334,6 +335,7 @@ void Sbar_Init(void)
 	Cvar_Register(&scr_scoreboard_wipeout);
 	Cvar_Register(&scr_scoreboard_classic);
 	Cvar_Register(&scr_scoreboard_highlightself);
+	Cvar_Register(&scr_scoreboard_showclock);
 
 	Cvar_ResetCurrentGroup();
 
@@ -1236,7 +1238,7 @@ void Sbar_SoloScoreboard (void)
 		len = strlen (str);
 		Sbar_DrawString (160 - len*4, 4, str);
 	}
-	else
+	else if (scr_scoreboard_showclock.value)
 	{
 		strlcpy(str, SCR_GetTimeString(TIMETYPE_CLOCK, "%H:%M:%S"), sizeof(str));
 		Sbar_DrawString(160 - (strlen(str)*4), -10, str);


### PR DESCRIPTION
Allow toggling the visibility of the clock at the bottom of the screen when using +showscores or +showteamscores.

`scr_scoreboard_showclock 0`:
![scr_scoreboard_showclock_0](https://github.com/user-attachments/assets/7d41892e-52c5-4c42-8df6-676a98279048)

`scr_scoreboard_showclock 1`:
![scr_scoreboard_showclock_1](https://github.com/user-attachments/assets/f91bcca7-367e-4f5b-a37b-8b87468eddd5)
