### PR TITLE
Allow orange, bright red and black colors

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -651,6 +651,18 @@
         {
           "description": "Blue",
           "name": "13"
+        },
+        {
+          "description": "Orange.",
+          "name": "14"
+        },
+        {
+          "description": "Bright red.",
+          "name": "15"
+        },
+        {
+          "description": "Black.",
+          "name": "16"
         }
       ]
     },
@@ -4124,6 +4136,18 @@
         {
           "description": "Blue",
           "name": "13"
+        },
+        {
+          "description": "Orange.",
+          "name": "14"
+        },
+        {
+          "description": "Bright red.",
+          "name": "15"
+        },
+        {
+          "description": "Black.",
+          "name": "16"
         }
       ]
     },
@@ -4236,6 +4260,18 @@
         {
           "description": "Blue",
           "name": "13"
+        },
+        {
+          "description": "Orange.",
+          "name": "14"
+        },
+        {
+          "description": "Bright red.",
+          "name": "15"
+        },
+        {
+          "description": "Black.",
+          "name": "16"
         }
       ]
     },
@@ -20694,6 +20730,18 @@
         {
           "description": "Blue",
           "name": "13"
+        },
+        {
+          "description": "Orange.",
+          "name": "14"
+        },
+        {
+          "description": "Bright red.",
+          "name": "15"
+        },
+        {
+          "description": "Black.",
+          "name": "16"
         }
       ]
     },
@@ -20847,6 +20895,18 @@
         {
           "description": "Blue",
           "name": "13"
+        },
+        {
+          "description": "Orange.",
+          "name": "14"
+        },
+        {
+          "description": "Bright red.",
+          "name": "15"
+        },
+        {
+          "description": "Black.",
+          "name": "16"
         }
       ]
     },
@@ -20932,6 +20992,18 @@
         {
           "description": "Blue.",
           "name": "13"
+        },
+        {
+          "description": "Orange.",
+          "name": "14"
+        },
+        {
+          "description": "Bright red.",
+          "name": "15"
+        },
+        {
+          "description": "Black.",
+          "name": "16"
         }
       ]
     },

--- a/src/cl_cmd.c
+++ b/src/cl_cmd.c
@@ -746,7 +746,7 @@ void CL_Color_f (void) {
 			Com_Printf ("\"color\" is \"%s %s\"\n",
 				Info_ValueForKey (cls.userinfo, "topcolor"),
 				Info_ValueForKey (cls.userinfo, "bottomcolor") );
-			Com_Printf ("color <0-13> [0-13]\n");
+			Com_Printf ("color <0-16> [0-16]\n");
 			return;
 		case 2:
 			top = bottom = Q_atoi(Cmd_Argv(1));
@@ -756,13 +756,8 @@ void CL_Color_f (void) {
 			bottom = Q_atoi(Cmd_Argv(2));
 	}
 
-	top &= 15;
-	top = min(top, 13);
-	bottom &= 15;
-	bottom = min(bottom, 13);
-
-	Cvar_SetValue (&topcolor, top);
-	Cvar_SetValue (&bottomcolor, bottom);
+	Cvar_SetValue (&topcolor, bound(0, top, 16));
+	Cvar_SetValue (&bottomcolor, bound(0, bottom, 16));
 }
 
 //usage: fullinfo \name\unnamed\topcolor\0\bottomcolor\1, etc

--- a/src/sbar.c
+++ b/src/sbar.c
@@ -441,9 +441,7 @@ void Sbar_DrawNum (int x, int y, int num, int digits, int color) {
 
 // this used to be static function
 int	Sbar_ColorForMap (int m) {
-	m = bound(0, m, 13);
-
-	return 16 * m + 8;
+	return m == 16 ? 0 : 16 * bound(0, m, 15) + 8;
 }
 
 // HUD -> hexum

--- a/src/teamplay.c
+++ b/src/teamplay.c
@@ -1895,13 +1895,8 @@ void TP_ColorForcing (cvar_t *topcolor, cvar_t *bottomcolor)
 		bottom = atoi(Cmd_Argv(2));
 	}
 
-	top &= 15;
-	top = min(13, top);
-	bottom &= 15;
-	bottom = min(13, bottom);
-
-	Cvar_SetValue(topcolor, top);
-	Cvar_SetValue(bottomcolor, bottom);
+	Cvar_SetValue(topcolor, bound(0, top, 16));
+	Cvar_SetValue(bottomcolor, bound(0, bottom, 16));
 
 	TP_RefreshSkins();
 }


### PR DESCRIPTION
There was a version of qwcl where you could use black and orange colors, but I haven't been able to figure out which version included them or when they were removed.

The current color selection algorithm works like `x * 16 + 8`, where `x` is a row in the Quake palette (as seen here: https://quakewiki.org/wiki/Quake_palette).

So, `color 0` is the same as `0 * 16 + 8`, which maps perfectly to the white color in the palette. The same goes for the other colors between 0 and 13.

I'm uncertain about the exact shade of orange that was possible to use, but my guess is that it was `14 * 16 + 8 == 232`.

`color 14`:
![color14](https://github.com/user-attachments/assets/0c94771b-d1a0-4959-9132-52fb02de6eb4)

`color 15`:
![color15](https://github.com/user-attachments/assets/ef489ea8-bdc6-4d16-aed9-64eaa434b240)

Old screenshot that demonstrates the black color:
https://www.quakeworld.nu/w/images/4/4c/RFVSSC1.JPG