### PR TITLE
Allow two exec calls during a game

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -773,6 +773,10 @@ typedef struct {
 	float map_fog_density;
 	qbool map_fog_enabled;
 	float map_fog_sky;
+
+	// exec_count keeps track of how many /exec calls have been made during a
+	// game, the counter will be reset upon match start.
+	int exec_count;
 } clientState_t;
 
 #define SCORING_SYSTEM_DEFAULT   0

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -554,10 +554,25 @@ void Cmd_Exec_f (void)
 	char *f, name[MAX_OSPATH];
 	char reset_bindphysical[128];
 	qbool server_command = false;
+	const int max_exec_calls = 2;
 
-	if (Rulesets_RestrictExec()) {
-		Com_Printf("The use of exec is not allowed during matches\n");
-		return;
+	if (Rulesets_RestrictExec())
+	{
+		if (cl.exec_count >= max_exec_calls)
+		{
+			Com_Printf("You have no remaining exec calls for this game\n");
+			return;
+		}
+
+		cl.exec_count++;
+		if (cl.exec_count < max_exec_calls)
+		{
+			Com_Printf("You have %d exec calls remaining\n", max_exec_calls - cl.exec_count);
+		}
+		else
+		{
+			Com_Printf("This was your last exec call for this game\n");
+		}
 	}
 
 	if (Cmd_Argc () != 2) {

--- a/src/match_tools.c
+++ b/src/match_tools.c
@@ -692,6 +692,7 @@ static void MT_StartMatch(void)
 	cl.countdown = false;
 	cl.gametime = 0;
 	cl.gamestarttime = Sys_DoubleTime();
+	cl.exec_count = 0;
 
 	if (cls.state < ca_active) {
 		matchstate.matchtype = mt_empty;


### PR DESCRIPTION
After this update, the rulesets that previously restricted exec calls now allows up to two exec calls per game.