### PR TITLE
RENDERER: enable centroid sampling for world geometry

### DIFF
--- a/src/glsl/draw_world.fragment.glsl
+++ b/src/glsl/draw_world.fragment.glsl
@@ -27,7 +27,7 @@ layout(std140, binding=EZQ_GL_BINDINGPOINT_BRUSHMODEL_SAMPLERS) buffer SamplerMa
 };
 
 in vec3 TextureCoord;
-in vec3 TexCoordLightmap;
+centroid in vec3 TexCoordLightmap;
 #ifdef DRAW_DETAIL_TEXTURES
 in vec2 DetailCoord;
 #endif

--- a/src/glsl/draw_world.vertex.glsl
+++ b/src/glsl/draw_world.vertex.glsl
@@ -11,7 +11,7 @@ layout(location = 5) in int vboFlags;
 layout(location = 6) in vec3 flatColor;
 layout(location = 7) in int surfaceNumber;
 
-out vec3 TexCoordLightmap;
+centroid out vec3 TexCoordLightmap;
 out vec3 TextureCoord;
 #ifdef DRAW_TEXTURELESS
 out vec3 TextureLessCoord;

--- a/src/glsl/glc/glc_world_drawflat.fragment.glsl
+++ b/src/glsl/glc/glc_world_drawflat.fragment.glsl
@@ -5,10 +5,10 @@
 #ifdef EZ_USE_TEXTURE_ARRAYS
 #extension GL_EXT_texture_array : enable
 uniform sampler2DArray texSampler;
-varying vec3 TextureCoord;
+centroid varying vec3 TextureCoord;
 #else
 uniform sampler2D texSampler;
-varying vec2 TextureCoord;
+centroid varying vec2 TextureCoord;
 #endif
 
 varying float lightmapScale;

--- a/src/glsl/glc/glc_world_drawflat.vertex.glsl
+++ b/src/glsl/glc/glc_world_drawflat.vertex.glsl
@@ -5,9 +5,9 @@
 attribute float style;
 varying vec4 color;
 #ifdef EZ_USE_TEXTURE_ARRAYS
-varying vec3 TextureCoord;
+centroid varying vec3 TextureCoord;
 #else
-varying vec2 TextureCoord;
+centroid varying vec2 TextureCoord;
 #endif
 varying float lightmapScale;
 varying float fogScale;

--- a/src/glsl/glc/glc_world_textured.fragment.glsl
+++ b/src/glsl/glc/glc_world_textured.fragment.glsl
@@ -64,10 +64,10 @@ varying vec2 TextureCoord;
 #ifdef DRAW_LIGHTMAPS
 #ifdef EZ_USE_TEXTURE_ARRAYS
 uniform sampler2DArray lightmapSampler;
-varying vec3 LightmapCoord;
+centroid varying vec3 LightmapCoord;
 #else
 uniform sampler2D lightmapSampler;
-varying vec2 LightmapCoord;
+centroid varying vec2 LightmapCoord;
 #endif
 #endif
 

--- a/src/glsl/glc/glc_world_textured.vertex.glsl
+++ b/src/glsl/glc/glc_world_textured.vertex.glsl
@@ -7,9 +7,9 @@ attribute float style;
 
 #ifdef DRAW_LIGHTMAPS
 #ifdef EZ_USE_TEXTURE_ARRAYS
-varying vec3 LightmapCoord;
+centroid varying vec3 LightmapCoord;
 #else
-varying vec2 LightmapCoord;
+centroid varying vec2 LightmapCoord;
 #endif
 #endif
 #ifdef DRAW_EXTRA_TEXTURES


### PR DESCRIPTION
Prevents bright artifacts along BSP splits in dark areas when using MSAA.