### PR TITLE
Restrict play in ruleset smack{down,drive}

### DIFF
--- a/src/rulesets.c
+++ b/src/rulesets.c
@@ -447,6 +447,7 @@ static void Rulesets_Thunderdome(qbool enable)
 		rulesetDef.restrictSetCalc = true;
 		rulesetDef.restrictSetEval = true;
 		rulesetDef.restrictSetEx = true;
+		rulesetDef.restrictPlay = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -466,6 +467,7 @@ static void Rulesets_Thunderdome(qbool enable)
 		rulesetDef.restrictSetCalc = false;
 		rulesetDef.restrictSetEval = false;
 		rulesetDef.restrictSetEx = false;
+		rulesetDef.restrictPlay = false;
 	}
 }
 static void Rulesets_MTFL(qbool enable)

--- a/src/rulesets.c
+++ b/src/rulesets.c
@@ -33,7 +33,7 @@ typedef struct rulesetDef_s {
 	qbool restrictTriggers;
 	qbool restrictPacket;
 	qbool restrictParticles;
-	qbool restrictSound;
+	qbool restrictPlay;
 	qbool restrictLogging;
 	qbool restrictRollAngle;
 	qbool restrictIPC;
@@ -186,9 +186,9 @@ qbool Rulesets_RestrictTriggers(void)
 	return rulesetDef.restrictTriggers;
 }
 
-qbool Rulesets_RestrictSound(const char* name)
+qbool Rulesets_RestrictPlay(const char* name)
 {
-	if (!rulesetDef.restrictSound) {
+	if (!rulesetDef.restrictPlay) {
 		return false;
 	}
 
@@ -314,7 +314,7 @@ static void Rulesets_Smackdown(qbool enable)
 		rulesetDef.restrictSetCalc = true;
 		rulesetDef.restrictSetEval = true;
 		rulesetDef.restrictSetEx = true;
-		rulesetDef.restrictSound = true;
+		rulesetDef.restrictPlay = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -334,7 +334,7 @@ static void Rulesets_Smackdown(qbool enable)
 		rulesetDef.restrictSetCalc = false;
 		rulesetDef.restrictSetEval = false;
 		rulesetDef.restrictSetEx = false;
-		rulesetDef.restrictSound = false;
+		rulesetDef.restrictPlay = false;
 	}
 }
 
@@ -372,7 +372,7 @@ static void Rulesets_Qcon(qbool enable)
 		rulesetDef.restrictTriggers = true;
 		rulesetDef.restrictPacket = true; // packet command could have been exploited for external timers
 		rulesetDef.restrictParticles = true;
-		rulesetDef.restrictSound = true;
+		rulesetDef.restrictPlay = true;
 		rulesetDef.restrictLogging = true;
 		rulesetDef.restrictRollAngle = true;
 		rulesetDef.ruleset = rs_qcon;
@@ -392,7 +392,7 @@ static void Rulesets_Qcon(qbool enable)
 		rulesetDef.restrictTriggers = false;
 		rulesetDef.restrictPacket = false;
 		rulesetDef.restrictParticles = false;
-		rulesetDef.restrictSound = false;
+		rulesetDef.restrictPlay = false;
 		rulesetDef.restrictLogging = false;
 		rulesetDef.restrictRollAngle = false;
 		rulesetDef.ruleset = rs_default;
@@ -574,7 +574,7 @@ static void Rulesets_Smackdrive(qbool enable)
 		rulesetDef.restrictSetCalc = true;
 		rulesetDef.restrictSetEval = true;
 		rulesetDef.restrictSetEx = true;
-		rulesetDef.restrictSound = true;
+		rulesetDef.restrictPlay = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -594,7 +594,7 @@ static void Rulesets_Smackdrive(qbool enable)
 		rulesetDef.restrictSetCalc = false;
 		rulesetDef.restrictSetEval = false;
 		rulesetDef.restrictSetEx = false;
-		rulesetDef.restrictSound = false;
+		rulesetDef.restrictPlay = false;
 	}
 }
 

--- a/src/rulesets.c
+++ b/src/rulesets.c
@@ -192,6 +192,10 @@ qbool Rulesets_RestrictPlay(const char* name)
 		return false;
 	}
 
+	if (cls.state == ca_active && (cl.spectator || cls.demoplayback || cl.standby)) {
+		return false;
+	}
+
 	if (name == NULL || cbuf_current != &cbuf_svc) {
 		return true;
 	}

--- a/src/rulesets.c
+++ b/src/rulesets.c
@@ -314,6 +314,7 @@ static void Rulesets_Smackdown(qbool enable)
 		rulesetDef.restrictSetCalc = true;
 		rulesetDef.restrictSetEval = true;
 		rulesetDef.restrictSetEx = true;
+		rulesetDef.restrictSound = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -333,6 +334,7 @@ static void Rulesets_Smackdown(qbool enable)
 		rulesetDef.restrictSetCalc = false;
 		rulesetDef.restrictSetEval = false;
 		rulesetDef.restrictSetEx = false;
+		rulesetDef.restrictSound = false;
 	}
 }
 
@@ -572,6 +574,7 @@ static void Rulesets_Smackdrive(qbool enable)
 		rulesetDef.restrictSetCalc = true;
 		rulesetDef.restrictSetEval = true;
 		rulesetDef.restrictSetEx = true;
+		rulesetDef.restrictSound = true;
 	} else {
 		for (i = 0; i < (sizeof(disabled_cvars) / sizeof(disabled_cvars[0])); i++)
 			Cvar_SetFlags(disabled_cvars[i].var, Cvar_GetFlags(disabled_cvars[i].var) & ~CVAR_ROM);
@@ -591,6 +594,7 @@ static void Rulesets_Smackdrive(qbool enable)
 		rulesetDef.restrictSetCalc = false;
 		rulesetDef.restrictSetEval = false;
 		rulesetDef.restrictSetEx = false;
+		rulesetDef.restrictSound = false;
 	}
 }
 

--- a/src/rulesets.h
+++ b/src/rulesets.h
@@ -61,7 +61,7 @@ qbool Rulesets_RestrictSetEval(void);
 qbool Rulesets_RestrictSetEx(void);
 qbool Rulesets_AllowNoShadows(void);
 qbool Rulesets_RestrictTCL(void);
-qbool Rulesets_RestrictSound(const char* name);
+qbool Rulesets_RestrictPlay(const char* name);
 int Rulesets_MaxSequentialWaitCommands(void);
 qbool Ruleset_BlockHudPicChange(void);
 qbool Ruleset_AllowPolygonOffset(entity_t* ent);

--- a/src/snd_main.c
+++ b/src/snd_main.c
@@ -996,7 +996,8 @@ static void S_Play_f (void)
 		int entity = SELF_SOUND_ENTITY;   // ezhfan: pnum+1 changed to SELF_SOUND to make sound not to disappear
 
 		strlcpy (name, Cmd_Argv(i), sizeof(name));
-		if (Rulesets_RestrictSound(name)) {
+		if (Rulesets_RestrictPlay(name)) {
+			Com_Printf("The use of play is not allowed during matches\n");
 			continue;
 		}
 


### PR DESCRIPTION
The `play` command was previously restricted only in the `qcon` ruleset. This PR extends the restriction to `smackdown` and `smackdrive` as well.

Additionally, it includes a minor refactor to better align the function with other restriction functions - specifically, ensuring that `play` is only be prevented during an ongoing game and allowed in prewar.

Thanks to gnoffa for pointing out that the `play` command should be restricted!