### PR TITLE
hardcode REVISION 1 because REVISION 0 breaks teaminfo

### DIFF
--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -1925,6 +1925,10 @@ static void CL_InitLocal(void)
 	// debugging weapons
 	Cvar_Register(&cl_debug_weapon_view);
 
+#if REVISION == 0
+#define REVISION 1
+#endif
+
 	snprintf(st, sizeof(st), "ezQuake %i", REVISION);
 
 	if (COM_CheckParm (cmdline_param_client_norjscripts) || COM_CheckParm (cmdline_param_client_noscripts))


### PR DESCRIPTION
Building from a tarball or from a shallow git clone sets REVISION to 0. This causes a bug where teaminfo does not display.

cl_main.c in ezquake sets *client StarKey as "ezQuake 0".

https://github.com/QW-Group/ezquake-source/blob/ef3d7c76d348dd6e985c56abdd00f1ad6a70ab06/src/cl_main.c#L1928-L1933

gmain.c in ktx sets p->ezquake_version to 0 based on this.

https://github.com/QW-Group/ktx/blob/2fde73e56383d973fb77b0cbdc59cfe713d45e56/src/g_main.c#L630

client.c in ktx checks for p->ezquake_version > 0 before calling SendTeamInfo(p).

https://github.com/QW-Group/ktx/blob/2fde73e56383d973fb77b0cbdc59cfe713d45e56/src/client.c#L4490-L4494

An alternative is to mess around with REVISION in GitUtils.cmake:
https://github.com/QW-Group/ezquake-source/blob/ef3d7c76d348dd6e985c56abdd00f1ad6a70ab06/cmake/GitUtils.cmake#L42
https://github.com/QW-Group/ezquake-source/blob/ef3d7c76d348dd6e985c56abdd00f1ad6a70ab06/cmake/GitUtils.cmake#L79

Steps to reproduce the problem:
1. Download github tarball https://github.com/QW-Group/ezquake-source/archive/refs/heads/master.zip
2. obtain qwprot elsewhere
3.  build from source: mkdir build && cd build
cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release 2>&1 | tee my_configure
make -j1 2>&1 | tee my_build
4. have two clients connect to a server and set to 4on4
5. teaminfo does not display