### PR TITLE
Add scr_scoreboard_showmapname and hud_scoremapname variables

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -11524,6 +11524,84 @@
       "group-id": "19",
       "type": "boolean"
     },
+    "hud_scoremapname_align_x": {
+      "desc": "Sets horizontal align of scoremapname.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoremapname_align_y": {
+      "desc": "Sets vertical align of scoremapname.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoremapname_frame": {
+      "desc": "Sets frame visibility and style for scoremapname.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoremapname_frame_color": {
+      "desc": "Defines the color of the background of the scoremapname HUD element. See HUD manual for more info.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoremapname_item_opacity": {
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoremapname_order": {
+      "desc": "This defines the order of drawing the HUD elements. That means you can change will be drawn on top of other elements. See HUD manual for more info.",
+      "group-id": "19",
+      "type": "integer"
+    },
+    "hud_scoremapname_place": {
+      "desc": "Sets relative positioning for scoremapname.",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_scoremapname_pos_x": {
+      "desc": "Sets horizontal position of scoremapname.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoremapname_pos_y": {
+      "desc": "Sets vertical position of scoremapname.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoremapname_proportional": {
+      "desc": "Toggles whether the scoremapname uses charset chars or TTF chars",
+      "group-id": "19",
+      "type": "boolean"
+    },
+    "hud_scoremapname_scale": {
+      "desc": "Scale of the scoremapname HUD element.",
+      "group-id": "19",
+      "type": "float"
+    },
+    "hud_scoremapname_style": {
+      "desc": "Style of the scoremapname HUD element.",
+      "group-id": "19",
+      "type": "enum",
+      "values": [
+        {
+          "description": "Full name, example: The Abandoned Base (dm3)",
+          "name": "0"
+        },
+        {
+          "description": "Level name, example: The Abandoned Base",
+          "name": "1"
+        },
+        {
+          "description": "Map name, example: dm3",
+          "name": "2"
+        }
+      ]
+    },
+    "hud_scoremapname_show": {
+      "desc": "Toggles whether the scoremapname is displayed. It is only displayed when the scoreboard is open.",
+      "group-id": "19",
+      "type": "boolean"
+    },
     "hud_sigil1_align_x": {
       "desc": "Sets horizontal align of sigil 1 icon (rune)",
       "group-id": "19",
@@ -19154,6 +19232,29 @@
         {
           "description": "Show the clock on the scoreboard.",
           "name": "true"
+        }
+      ]
+    },
+    "scr_scoreboard_showmapname": {
+      "default": "0",
+      "group-id": "47",
+      "type": "enum",
+      "values": [
+        {
+          "description": "Don't display the level name",
+          "name": "0"
+        },
+        {
+          "description": "Full name, example: The Abandoned Base (dm3)",
+          "name": "1"
+        },
+        {
+          "description": "Level name, example: The Abandoned Base",
+          "name": "2"
+        },
+        {
+          "description": "Map name, example: dm3",
+          "name": "3"
         }
       ]
     },

--- a/src/hud_gamesummary.c
+++ b/src/hud_gamesummary.c
@@ -197,6 +197,40 @@ static void SCR_Hud_GameSummary(hud_t* hud)
 	}
 }
 
+static void SCR_HUD_DrawScoreMapName(hud_t *hud) {
+	static cvar_t *proportional = NULL, *scale, *style;
+	int w, h, x, y;
+	char str[256];
+
+	if (proportional == NULL)
+	{
+		proportional = HUD_FindVar(hud, "proportional");
+		scale = HUD_FindVar(hud, "scale");
+		style = HUD_FindVar(hud, "style");
+	}
+
+	switch (style->integer)
+	{
+		case 1:
+			snprintf(str, sizeof(str), "%s", cl.levelname);
+			break;
+		case 2:
+			snprintf(str, sizeof(str), "%s", host_mapname.string);
+			break;
+		default:
+			snprintf(str, sizeof(str), "%s (%s)", cl.levelname, host_mapname.string);
+			break;
+	}
+
+	w = Draw_StringLengthColors(str, -1, scale->value, proportional->integer);
+	h = scale->value * 8;
+
+	if (!HUD_PrepareDraw(hud, w, h, &x, &y))
+		return;
+
+	Draw_SString(x, y, str, scale->value, proportional->integer);
+}
+
 void GameSummary_HudInit(void)
 {
 	HUD_Register(
@@ -211,6 +245,16 @@ void GameSummary_HudInit(void)
 		"ratio", "4",
 		"flash", "1",
 		"proportional", "0",
+		NULL
+	);
+
+	HUD_Register(
+		"scoremapname", NULL, "Shows map name on the scoreboard",
+		HUD_NO_DRAW | HUD_ON_INTERMISSION | HUD_ON_SCORES | HUD_ON_FINALE, ca_disconnected, 8, SCR_HUD_DrawScoreMapName,
+		"0", "screen", "right", "bottom", "0", "-10", "0", "0 0 0", NULL,
+		"style", "0",
+		"proportional", "0",
+		"scale", "1",
 		NULL
 	);
 }

--- a/src/sbar.c
+++ b/src/sbar.c
@@ -144,6 +144,7 @@ cvar_t  scr_scoreboard_wipeout	 	  = {"scr_scoreboard_wipeout",   	  "1"};
 cvar_t	scr_scoreboard_classic        = {"scr_scoreboard_classic", "0"};
 cvar_t	scr_scoreboard_highlightself  = {"scr_scoreboard_highlightself", "1"};
 cvar_t	scr_scoreboard_showclock      = {"scr_scoreboard_showclock", "0"};
+cvar_t	scr_scoreboard_showmapname    = {"scr_scoreboard_showmapname", "0"};
 
 // VFrags: only draw the frags for the first player when using mvinset
 #define MULTIVIEWTHISPOV() ((!cl_multiview.value) || (cl_mvinset.value && CL_MultiviewCurrentView() == 1))
@@ -336,6 +337,7 @@ void Sbar_Init(void)
 	Cvar_Register(&scr_scoreboard_classic);
 	Cvar_Register(&scr_scoreboard_highlightself);
 	Cvar_Register(&scr_scoreboard_showclock);
+	Cvar_Register(&scr_scoreboard_showmapname);
 
 	Cvar_ResetCurrentGroup();
 
@@ -1217,6 +1219,8 @@ void Sbar_SoloScoreboard (void)
 {
 	char	str[256];
 	int	len;
+	int	clock_y;
+	int	mapname_y;
 
 	if (cl.gametype == GAME_COOP)
 	{
@@ -1236,10 +1240,50 @@ void Sbar_SoloScoreboard (void)
 		len = strlen (str);
 		Sbar_DrawString (160 - len*4, 4, str);
 	}
-	else if (scr_scoreboard_showclock.value)
+	else
 	{
-		strlcpy(str, SCR_GetTimeString(TIMETYPE_CLOCK, "%H:%M:%S"), sizeof(str));
-		Sbar_DrawString(160 - (strlen(str)*4), -10, str);
+		if ((scr_scoreboard_showclock.integer && !scr_scoreboard_showmapname.integer))
+		{
+			clock_y = -10;
+		}
+		else if (!scr_scoreboard_showclock.integer && scr_scoreboard_showmapname.integer)
+		{
+			mapname_y = -10;
+		}
+		else if (scr_scoreboard_showclock.integer && scr_scoreboard_showmapname.integer == 3)
+		{
+			clock_y = 2;
+			mapname_y = -10;
+		}
+		else
+		{
+			clock_y = -10;
+			mapname_y = 2;
+		}
+
+		if (scr_scoreboard_showclock.integer)
+		{
+			snprintf(str, sizeof(str), "%s", SCR_GetTimeString(TIMETYPE_CLOCK, "%H:%M:%S"));
+			Sbar_DrawString(160 - strlen(str) * 4, clock_y, str);
+		}
+
+		if (scr_scoreboard_showmapname.integer)
+		{
+			switch (scr_scoreboard_showmapname.integer)
+			{
+				case 2:
+					snprintf(str, sizeof(str), "%s", cl.levelname);
+					break;
+				case 3:
+					snprintf(str, sizeof(str), "%s", host_mapname.string);
+					break;
+				default:
+					snprintf(str, sizeof(str), "%s (%s)", cl.levelname, host_mapname.string);
+					break;
+			}
+
+			Sbar_DrawString (160 - strlen(str) * 4, mapname_y, str);
+		}
 	}
 }
 


### PR DESCRIPTION
The new options allow you to display the current map name when +showscores / +showteamscores are toggled.

Example of the three display formats:

- Full name: The Abandoned Base (dm3)
- Level name: The Abandoned Base
- Map name: dm3

Example screenshots:
![hud_scoremapname_0](https://github.com/user-attachments/assets/8dc79141-27c6-4369-ad05-fb581aa1344c)
![hud_scoremapname_1](https://github.com/user-attachments/assets/76e2f35f-17ed-48a7-a7b0-cf63f19455e3)
![hud_scoremapname_2](https://github.com/user-attachments/assets/5019a7fa-81a8-41ba-a156-14029259278a)
![scr_scoreboard_showmapname_1](https://github.com/user-attachments/assets/9f74c818-54bd-490f-aaf3-36ae9b38acfc)
![scr_scoreboard_showmapname_2](https://github.com/user-attachments/assets/61d2b5a1-9d58-46f2-afda-6202ba3f4ea3)
![scr_scoreboard_showmapname_3](https://github.com/user-attachments/assets/72c81053-227f-455a-b121-f73304cac8e8)
