### PR TITLE
Add support for displaying QTV users in the scoreboard

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -15221,6 +15221,26 @@
       "group-id": "38",
       "type": "string"
     },
+    "qtv_event_msglevel": {
+      "default": "1",
+      "desc": "Controls the visibility of QTV event messages, allowing them to be enabled, disabled, or hidden during an active match.",
+      "group-id": "38",
+      "type": "enum",
+      "values": [
+        {
+          "description": "Disables QTV event messages.",
+          "name": "0"
+        },
+        {
+          "description": "Enables QTV event messages.",
+          "name": "1"
+        },
+        {
+          "description": "Hides QTV event messages when a match has started.",
+          "name": "2"
+        }
+      ]
+    },
     "qtv_gamechatprefix": {
       "default": "$[{QTV>game}$] ",
       "desc": "String that will be added at the beginning of all messages send from QTV to the server where the broadcasted game is being played.",
@@ -19276,6 +19296,26 @@
           "name": "true"
         }
       ]
+    },
+    "scr_scoreboard_showqtvusers": {
+      "default": "0",
+      "group-id": "47",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Disable QTV users in the scoreboard.",
+          "name": "false"
+        },
+        {
+          "description": "Enable QTV users in the scoreboard.",
+          "name": "true"
+        }
+      ]
+    },
+    "scr_scoreboard_qtv_name": {
+      "desc": "This variable will change what qtv users are called in the scoreboard.\nWhen teamplay is not on, this variable is cut to 4 characters.\n&cRGB values are not accepted.",
+      "group-id": "47",
+      "type": "string"
     },
     "scr_scoreboard_spectator_name": {
       "desc": "This variable will change what spectators are called in the scoreboard.\nWhen teamplay is not on, this variable is cut to 4 characters.\n&cRGB values are not accepted.",

--- a/src/qtv.h
+++ b/src/qtv.h
@@ -58,7 +58,8 @@ typedef enum {
 	QUL_NONE = 0,	//
 	QUL_ADD,		// user joined
 	QUL_CHANGE,		// user changed something like name or something
-	QUL_DEL			// user dropped
+	QUL_DEL,		// user dropped
+	QUL_INIT		// user init
 } qtvuserlist_t;
 
 typedef struct qtvuser_s {


### PR DESCRIPTION
By setting scr_scoreboard_showqtvusers to 1, you can display the currently connected QTV users in the scoreboard.

This feature requires an MVDSV server capable of relaying QTV events to regular clients.

New variables:

- scr_scoreboard_showqtvusers (default: 0)
- scr_scoreboard_qtv_name (default: qtv)
- qtv_event_msglevel (default: 1)
	0: Disables QTV event messages
	1: Enables QTV event messages
	2: Hides QTV event messages when a match has started
	
Screenshot:
![ezquake000](https://github.com/user-attachments/assets/05795b83-62c9-4949-b1b5-3013544c60e9)

Depends on: https://github.com/QW-Group/mvdsv/pull/168
