### PR TITLE
PMOVE: Add pm_surffix server cvar.

### DIFF
--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -2385,6 +2385,7 @@ void CL_ProcessServerInfo (void)
 		&& (cl.z_ext & Z_EXT_PF_ONGROUND) /* pground doesn't make sense without this */;
 	movevars.ktjump = *(p = Info_ValueForKey(cl.serverinfo, "pm_ktjump")) ? Q_atof(p) : cl.teamfortress ? 0 : 1;
 	movevars.rampjump = (Q_atof(Info_ValueForKey(cl.serverinfo, "pm_rampjump")) != 0);
+	movevars.surffix = (Q_atof(Info_ValueForKey(cl.serverinfo, "pm_surffix")) != 0);
 
 	// Deathmatch and teamplay.
 	cl.deathmatch = atoi(Info_ValueForKey(cl.serverinfo, "deathmatch"));

--- a/src/pmove.h
+++ b/src/pmove.h
@@ -86,6 +86,7 @@ typedef struct {
 	qbool	airstep;
 	qbool	pground; // NQ-style "onground" flag handling.
 	int     rampjump; // if set, all vertical velocity clipped by groundplane during jump frame.  If 0, only when falling (standard jumpfix)
+	qbool	surffix; // Sliding fix for surf maps.
 } movevars_t;
 
 extern movevars_t movevars;

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3343,6 +3343,7 @@ void SV_InitLocal (void)
 	extern	cvar_t	pm_pground;
 	extern  cvar_t  pm_rampjump;
 	extern	cvar_t	pm_slidefix;
+	extern	cvar_t	pm_surffix;
 	extern	cvar_t	pm_ktjump;
 	extern	cvar_t	pm_bunnyspeedcap;
 
@@ -3452,6 +3453,7 @@ void SV_InitLocal (void)
 	Cvar_Register (&pm_bunnyspeedcap);
 	Cvar_Register (&pm_ktjump);
 	Cvar_Register (&pm_slidefix);
+	Cvar_Register (&pm_surffix);
 	Cvar_Register (&pm_pground);
 	Cvar_Register (&pm_airstep);
 	Cvar_Register (&pm_rampjump);

--- a/src/sv_phys.c
+++ b/src/sv_phys.c
@@ -64,6 +64,7 @@ void OnChange_pm_airstep (cvar_t *var, char *value, qbool *cancel);
 cvar_t	pm_airstep		= { "pm_airstep", "", CVAR_SERVERINFO, OnChange_pm_airstep};
 cvar_t	pm_pground		= { "pm_pground", "", CVAR_SERVERINFO|CVAR_ROM};
 cvar_t  pm_rampjump     = { "pm_rampjump", "", CVAR_SERVERINFO };
+cvar_t	pm_surffix		= { "pm_surffix", "", CVAR_SERVERINFO};
 
 double	sv_frametime;
 

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -98,6 +98,7 @@ extern cvar_t   pm_slidefix;
 extern cvar_t   pm_airstep;
 extern cvar_t   pm_pground;
 extern cvar_t   pm_rampjump;
+extern cvar_t   pm_surffix;
 extern double	sv_frametime;
 
 //bliP: init ->
@@ -3675,6 +3676,7 @@ FIXME
 	movevars.airstep = ((int)pm_airstep.value != 0);
 	movevars.pground = ((int)pm_pground.value != 0);
 	movevars.rampjump = ((int)pm_rampjump.value != 0);
+	movevars.surffix = ((int)pm_surffix.value != 0);
 
 	// do the move
 	blocked = PM_PlayerMove ();


### PR DESCRIPTION
pm_surffix:
  1 - Alters player sliding movement; useful for so-called surf maps.
  "" - Default, uses original QW sliding movement.
  
  Sillybilly's code, I provide it as PR, untested.