### PR TITLE
Add ignore_{no_weapon,not_enough_ammo}

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -13453,6 +13453,38 @@
         }
       ]
     },
+    "ignore_no_weapon": {
+      "default": "0",
+      "desc": "Toggle showing the \"no weapon.\" message emitted by KTX when attempting to fire a weapon you don't have.",
+      "group-id": "3",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "",
+          "name": "false"
+        },
+        {
+          "description": "",
+          "name": "true"
+        }
+      ]
+    },
+    "ignore_not_enough_ammo": {
+      "default": "0",
+      "desc": "Toggle showing the \"not enough ammo.\" message emitted by KTX when attempting to fire a weapon without enough ammo.",
+      "group-id": "3",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "",
+          "name": "false"
+        },
+        {
+          "description": "",
+          "name": "true"
+        }
+      ]
+    },
     "image_jpeg_quality_level": {
       "default": "75",
       "desc": "You can set quality of jpeg screenshots with 'image_jpeg_quality_level x' where x is an integer from 0 to 100 inclusive.\nThe larger x is, the better the quality of a jpeg screenshot, but also the bigger the size.",

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -2866,6 +2866,9 @@ void CL_ProcessPrint (int level, char* s0)
 	char *chat_sound_file;
 	float chat_sound_vol = 0.0;
 
+	extern cvar_t ignore_no_weapon;
+	extern cvar_t ignore_not_enough_ammo;
+
 	// { QTV: check do this string is QTV chat
 	qtvtmp = SkipQTVLeadingProxies(s0);
 
@@ -3050,6 +3053,17 @@ void CL_ProcessPrint (int level, char* s0)
 				if (*p == 0x0D || (*p == 0x0A && p[1]))
 					*p = ' ';
 			}
+		}
+	}
+	else if (level == PRINT_HIGH)
+	{
+		if (ignore_no_weapon.integer > 0 && strncmp(s0, "no weapon", 9) == 0)
+		{
+			return;
+		}
+		else if (ignore_not_enough_ammo.integer > 0 && strncmp(s0, "not enough ammo", 15) == 0)
+		{
+			return;
 		}
 	}
 

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -36,6 +36,8 @@ cvar_t		ignore_mode				= {"ignore_mode", "0"};
 cvar_t		ignore_flood_duration	= {"ignore_flood_duration", "4"};
 cvar_t		ignore_flood			= {"ignore_flood", "0"};		
 cvar_t		ignore_opponents		= {"ignore_opponents", "0"};
+cvar_t		ignore_no_weapon		= {"ignore_no_weapon", "0"};
+cvar_t		ignore_not_enough_ammo		= {"ignore_not_enough_ammo", "0"};
 
 char ignoreteamlist[MAX_TEAMIGNORELIST][16 + 1];
 
@@ -507,6 +509,8 @@ void Ignore_Init(void) {
 	Cvar_Register (&ignore_qtv);
 	Cvar_Register (&ignore_mode);
 	Cvar_Register (&ignore_opponents);
+	Cvar_Register (&ignore_no_weapon);
+	Cvar_Register (&ignore_not_enough_ammo);
 
 	Cvar_ResetCurrentGroup();
 


### PR DESCRIPTION
Setting ignore_no_weapon to 1 will suppress the "no weapon." message emitted by KTX. Similarly, ignore_not_enough_ammo will suppress the "not enough ammo." message.