### PR TITLE
Initialize results to NULL so it's always safe to free

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1835,7 +1835,7 @@ static int NET_PortPingProbeOrchestrator(void *data)
 {
 	portpingprobe_orchestrator_args_t *args = (portpingprobe_orchestrator_args_t *)data;
 	portpingprobe_status_t status = PORTPINGPROBE_READY;
-	portpingprobe_t *results;
+	portpingprobe_t *results = NULL;
 	SDL_Thread **workers = NULL;
 	struct sockaddr_in addr;
 	netadr_t net_addr;
@@ -1914,11 +1914,7 @@ static int NET_PortPingProbeOrchestrator(void *data)
 	status = PORTPINGPROBE_COMPLETED;
 
 cleanup:
-	if (workers != NULL)
-	{
-		Q_free(workers);
-	}
-
+	Q_free(workers);
 	Q_free(results);
 	Q_free(args->target_addr);
 	Q_free(args->original_addr);


### PR DESCRIPTION
This fixes the issue @BLooD-DoG reported earlier today (also previously mentioned by @sopparus, but I couldn't reproduce it at the time), where the client would crash.

The crash could be reproduced by:
1. Enabling port ping probing
2. Connecting to a server
3. Disconnecting from the server
4. Connecting to a server with an invalid hostname
5. Crash