### PR TITLE
Add hud_ammo[1-4]_text_color_{low,normal}

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -6281,6 +6281,16 @@
       "group-id": "19",
       "type": "float"
     },
+    "hud_ammo1_text_color_low": {
+      "desc": "Text color when low on shells (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_ammo1_text_color_normal": {
+      "desc": "Text color when shell count is normal (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
     "hud_ammo2_align": {
       "desc": "Sets align of number of nails.",
       "group-id": "19",
@@ -6349,6 +6359,16 @@
       "desc": "Switches graphical style of number of nails.",
       "group-id": "19",
       "type": "float"
+    },
+    "hud_ammo2_text_color_low": {
+      "desc": "Text color when low on nails (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_ammo2_text_color_normal": {
+      "desc": "Text color when nail count is normal (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
     },
     "hud_ammo3_align": {
       "desc": "Sets align of number of rockets.",
@@ -6419,6 +6439,16 @@
       "group-id": "19",
       "type": "float"
     },
+    "hud_ammo3_text_color_low": {
+      "desc": "Text color when low on rockets (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_ammo3_text_color_normal": {
+      "desc": "Text color when rocket count is normal (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
     "hud_ammo4_align": {
       "desc": "Sets align of number of cells.",
       "group-id": "19",
@@ -6487,6 +6517,16 @@
       "desc": "Switches graphical style of number of cells.",
       "group-id": "19",
       "type": "float"
+    },
+    "hud_ammo4_text_color_low": {
+      "desc": "Text color when low on cells (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_ammo4_text_color_normal": {
+      "desc": "Text color when cell count is normal (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
     },
     "hud_ammo_align": {
       "desc": "Sets align of current ammo value.",

--- a/src/hud.c
+++ b/src/hud.c
@@ -1405,6 +1405,35 @@ cvar_t *HUD_FindVar(hud_t *hud, char *subvar)
 }
 
 //
+// HUD_FindInitTextColorVar searches for a HUD element by name.
+//
+// If not found, returns NULL (same as HUD_FindVar).
+//
+// If found, apply the CVAR_COLOR flag to indicate the value should be parsed as
+// a color.
+//
+// If the variable has a value, it is re-assigned to trigger correct color
+// parsing.
+cvar_t *HUD_FindInitTextColorVar(hud_t *hud, char *name)
+{
+	cvar_t *cvar;
+
+	if ((cvar = HUD_FindVar(hud, name)) == NULL)
+	{
+		return NULL;
+	}
+
+	Cvar_SetFlags(cvar, Cvar_GetFlags(cvar) | CVAR_COLOR);
+
+	if (strlen(cvar->string) > 0)
+	{
+		Cvar_Set(cvar, cvar->string);
+	}
+
+	return cvar;
+}
+
+//
 // Draws single HUD element.
 //
 void HUD_DrawObject(hud_t *hud)

--- a/src/hud.h
+++ b/src/hud.h
@@ -149,6 +149,11 @@ void HUD_Draw(void);
 cvar_t *HUD_FindVar(hud_t *hud, char *subvar);
 
 //
+// Retrieve hud cvar by name and apply text color flags and parsing.
+//
+cvar_t *HUD_FindInitTextColorVar(hud_t *hud, char *name);
+
+//
 // Find element in list.
 //
 hud_t * HUD_Find(char *name);

--- a/src/hud_ammo.c
+++ b/src/hud_ammo.c
@@ -105,7 +105,8 @@ int HUD_AmmoLowByWeapon(int weapon)
 }
 
 static void SCR_HUD_DrawAmmo(
-	hud_t *hud, int num, float scale, int style, int digits, char *s_align, qbool proportional, qbool always
+	hud_t *hud, int num, float scale, int style, int digits, char *s_align, qbool proportional, qbool always,
+	byte *text_color_low, byte *text_color_normal
 )
 {
 	extern mpic_t sb_ib_ammo[4];
@@ -146,7 +147,7 @@ static void SCR_HUD_DrawAmmo(
 	if (!num && !always) {
 		if (style < 2 || style == 3) {
 			// use this to calculate sizes, but draw_content is false
-			SCR_HUD_DrawNum2(hud, 0, false, scale, style, digits, s_align, proportional, false);
+			SCR_HUD_DrawNum2(hud, 0, false, scale, style, digits, s_align, proportional, false, text_color_low, text_color_normal);
 		}
 		else {
 			int x_, y;
@@ -170,7 +171,7 @@ static void SCR_HUD_DrawAmmo(
 
 	if (style < 2 || style == 3) {
 		// simply draw number
-		SCR_HUD_DrawNum(hud, value, style == 3 ? false : low, scale, style, digits, s_align, proportional);
+		SCR_HUD_DrawNum2(hud, value, style == 3 ? false : low, scale, style, digits, s_align, proportional, true, text_color_low, text_color_normal);
 	}
 	else {
 		// else - draw classic ammo-count box with background
@@ -213,7 +214,7 @@ static void SCR_HUD_DrawAmmo(
 
 void SCR_HUD_DrawAmmoCurrent(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *digits, *align, *proportional, *always;
+	static cvar_t *scale = NULL, *style, *digits, *align, *proportional, *always, *text_color_low, *text_color_normal;
 	if (scale == NULL)  // first time called
 	{
 		scale = HUD_FindVar(hud, "scale");
@@ -222,15 +223,20 @@ void SCR_HUD_DrawAmmoCurrent(hud_t *hud)
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
 		always = HUD_FindVar(hud, "show_always");
+		text_color_low = HUD_FindInitTextColorVar(hud, "text_color_low");
+		text_color_normal = HUD_FindInitTextColorVar(hud, "text_color_normal");
 	}
 	if (cl.spectator == cl.autocam) {
-		SCR_HUD_DrawAmmo(hud, 0, scale->value, style->value, digits->value, align->string, proportional->integer, always->integer);
+		SCR_HUD_DrawAmmo(hud, 0, scale->value, style->value, digits->value, align->string,
+			proportional->integer, always->integer,
+			strlen(text_color_low->string) == 0 ? NULL : text_color_low->color,
+			strlen(text_color_normal->string) == 0 ? NULL : text_color_normal->color);
 	}
 }
 
 void SCR_HUD_DrawAmmo1(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *digits, *align, *proportional;
+	static cvar_t *scale = NULL, *style, *digits, *align, *proportional, *text_color_low, *text_color_normal;
 	if (scale == NULL)  // first time called
 	{
 		scale = HUD_FindVar(hud, "scale");
@@ -238,15 +244,21 @@ void SCR_HUD_DrawAmmo1(hud_t *hud)
 		digits = HUD_FindVar(hud, "digits");
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
+		text_color_low = HUD_FindInitTextColorVar(hud, "text_color_low");
+		text_color_normal = HUD_FindInitTextColorVar(hud, "text_color_normal");
 	}
+
 	if (cl.spectator == cl.autocam) {
-		SCR_HUD_DrawAmmo(hud, 1, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+		SCR_HUD_DrawAmmo(hud, 1, scale->value, style->value, digits->value, align->string,
+			proportional->integer, true,
+			strlen(text_color_low->string) == 0 ? NULL : text_color_low->color,
+			strlen(text_color_normal->string) == 0 ? NULL : text_color_normal->color);
 	}
 }
 
 void SCR_HUD_DrawAmmo2(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *digits, *align, *proportional;
+	static cvar_t *scale = NULL, *style, *digits, *align, *proportional, *text_color_low, *text_color_normal;
 	if (scale == NULL)  // first time called
 	{
 		scale = HUD_FindVar(hud, "scale");
@@ -254,15 +266,20 @@ void SCR_HUD_DrawAmmo2(hud_t *hud)
 		digits = HUD_FindVar(hud, "digits");
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
+		text_color_low = HUD_FindInitTextColorVar(hud, "text_color_low");
+		text_color_normal = HUD_FindInitTextColorVar(hud, "text_color_normal");
 	}
 	if (cl.spectator == cl.autocam) {
-		SCR_HUD_DrawAmmo(hud, 2, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+		SCR_HUD_DrawAmmo(hud, 2, scale->value, style->value, digits->value, align->string,
+			proportional->integer, true,
+			strlen(text_color_low->string) == 0 ? NULL : text_color_low->color,
+			strlen(text_color_normal->string) == 0 ? NULL : text_color_normal->color);
 	}
 }
 
 void SCR_HUD_DrawAmmo3(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *digits, *align, *proportional;
+	static cvar_t *scale = NULL, *style, *digits, *align, *proportional, *text_color_low, *text_color_normal;
 	if (scale == NULL)  // first time called
 	{
 		scale = HUD_FindVar(hud, "scale");
@@ -270,15 +287,20 @@ void SCR_HUD_DrawAmmo3(hud_t *hud)
 		digits = HUD_FindVar(hud, "digits");
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
+		text_color_low = HUD_FindInitTextColorVar(hud, "text_color_low");
+		text_color_normal = HUD_FindInitTextColorVar(hud, "text_color_normal");
 	}
 	if (cl.spectator == cl.autocam) {
-		SCR_HUD_DrawAmmo(hud, 3, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+		SCR_HUD_DrawAmmo(hud, 3, scale->value, style->value, digits->value, align->string,
+			proportional->integer, true,
+			strlen(text_color_low->string) == 0 ? NULL : text_color_low->color,
+			strlen(text_color_normal->string) == 0 ? NULL : text_color_normal->color);
 	}
 }
 
 void SCR_HUD_DrawAmmo4(hud_t *hud)
 {
-	static cvar_t *scale = NULL, *style, *digits, *align, *proportional;
+	static cvar_t *scale = NULL, *style, *digits, *align, *proportional, *text_color_low, *text_color_normal;
 	if (scale == NULL)  // first time called
 	{
 		scale = HUD_FindVar(hud, "scale");
@@ -286,9 +308,14 @@ void SCR_HUD_DrawAmmo4(hud_t *hud)
 		digits = HUD_FindVar(hud, "digits");
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
+		text_color_low = HUD_FindInitTextColorVar(hud, "text_color_low");
+		text_color_normal = HUD_FindInitTextColorVar(hud, "text_color_normal");
 	}
 	if (cl.spectator == cl.autocam) {
-		SCR_HUD_DrawAmmo(hud, 4, scale->value, style->value, digits->value, align->string, proportional->integer, true);
+		SCR_HUD_DrawAmmo(hud, 4, scale->value, style->value, digits->value, align->string,
+			proportional->integer, true,
+			strlen(text_color_low->string) == 0 ? NULL : text_color_low->color,
+			strlen(text_color_normal->string) == 0 ? NULL : text_color_normal->color);
 	}
 }
 
@@ -419,6 +446,8 @@ void Ammo_HudInit(void)
 		"digits", "3",
 		"proportional", "0",
 		"show_always", "0",
+		"text_color_low", "",
+		"text_color_normal", "",
 		 NULL
 	);
 
@@ -430,6 +459,8 @@ void Ammo_HudInit(void)
 				 "align", "right",
 				 "digits", "3",
 				 "proportional", "0",
+				 "text_color_low", "",
+				 "text_color_normal", "",
 				 NULL);
 	HUD_Register("ammo2", NULL, "Part of your inventory - ammo - nails.",
 				 HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawAmmo2,
@@ -439,6 +470,8 @@ void Ammo_HudInit(void)
 				 "align", "right",
 				 "digits", "3",
 				 "proportional", "0",
+				 "text_color_low", "",
+				 "text_color_normal", "",
 				 NULL);
 	HUD_Register("ammo3", NULL, "Part of your inventory - ammo - rockets.",
 				 HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawAmmo3,
@@ -448,6 +481,8 @@ void Ammo_HudInit(void)
 				 "align", "right",
 				 "digits", "3",
 				 "proportional", "0",
+				 "text_color_low", "",
+				 "text_color_normal", "",
 				 NULL);
 	HUD_Register("ammo4", NULL, "Part of your inventory - ammo - cells.",
 				 HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawAmmo4,
@@ -457,6 +492,8 @@ void Ammo_HudInit(void)
 				 "align", "right",
 				 "digits", "3",
 				 "proportional", "0",
+				 "text_color_low", "",
+				 "text_color_normal", "",
 				 NULL);
 
 	// ammo icon/s

--- a/src/hud_common.c
+++ b/src/hud_common.c
@@ -228,7 +228,8 @@ void SCR_HUD_DrawNotify(hud_t* hud)
 // status numbers
 void SCR_HUD_DrawNum2(
 	hud_t *hud, int num, qbool low,
-	float scale, int style, int digits, char *s_align, qbool proportional, qbool draw_content
+	float scale, int style, int digits, char *s_align, qbool proportional, qbool draw_content,
+	byte *text_color_low, byte *text_color_normal
 )
 {
 	extern mpic_t *sb_nums[2][11];
@@ -240,6 +241,8 @@ void SCR_HUD_DrawNum2(
 	int width, height, x, y;
 	int size;
 	int align;
+
+	clrinfo_t clr = { .i = 0 };
 
 	clamp(num, -99999, 999999);
 	scale = max(scale, 0.01);
@@ -348,7 +351,15 @@ void SCR_HUD_DrawNum2(
 			}
 
 			if (low) {
-				Draw_SAlt_String(x, y, buf, scale, proportional);
+				if (text_color_low != NULL)
+				{
+					clr.c = RGBAVECT_TO_COLOR(text_color_low);
+					Draw_SColoredAlphaString(x, y, buf, &clr, 1, 0, scale, 1.0, proportional);
+				}
+				else
+				{
+					Draw_SAlt_String(x, y, buf, scale, proportional);
+				}
 			}
 			else {
 				if(style == 3) {
@@ -359,7 +370,16 @@ void SCR_HUD_DrawNum2(
 						}
 					}
 				}
-				Draw_SString(x, y, buf, scale, proportional);
+
+				if (text_color_normal != NULL)
+				{
+					clr.c = RGBAVECT_TO_COLOR(text_color_normal);
+					Draw_SColoredAlphaString(x, y, buf, &clr, 1, 0, scale, 1.0, proportional);
+				}
+				else
+				{
+					Draw_SString(x, y, buf, scale, proportional);
+				}
 			}
 			break;
 
@@ -395,7 +415,7 @@ void SCR_HUD_DrawNum(
 	float scale, int style, int digits, char* s_align, qbool proportional
 )
 {
-	SCR_HUD_DrawNum2(hud, num, low, scale, style, digits, s_align, proportional, true);
+	SCR_HUD_DrawNum2(hud, num, low, scale, style, digits, s_align, proportional, true, NULL, NULL);
 }
 
 #define TEMPHUD_NAME "_temphud"

--- a/src/hud_common.h
+++ b/src/hud_common.h
@@ -34,7 +34,7 @@ void SCR_HUD_DrawRadar(hud_t *hud);
 
 void HudCommon_Init(void);
 void SCR_HUD_DrawNum(hud_t *hud, int num, qbool low, float scale, int style, int digits, char *s_align, qbool proportional);
-void SCR_HUD_DrawNum2(hud_t* hud, int num, qbool low, float scale, int style, int digits, char* s_align, qbool proportional, qbool draw_content);
+void SCR_HUD_DrawNum2(hud_t* hud, int num, qbool low, float scale, int style, int digits, char* s_align, qbool proportional, qbool draw_content, byte *text_color_low, byte *text_color_normal);
 
 extern qbool autohud_loaded;
 extern cvar_t mvd_autohud;


### PR DESCRIPTION
Variables:

- hud_ammo[1-4]_text_color_low: Text color when low on ammo.
- hud_ammo[1-4]_text_color_normal: Text color when ammo count is normal.

Screenshot:
![hud_ammo_text_color](https://github.com/user-attachments/assets/0780bca2-14f9-4fc5-8b65-2cfc14f4d830)

Feature requested by phren