### PR TITLE
Add hud armor health text color

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -6691,6 +6691,41 @@
       "group-id": "19",
       "type": "float"
     },
+    "hud_armor_text_color_none": {
+      "desc": "Text color when no armor is equipped (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_armor_text_color_ga_low": {
+      "desc": "Text color when low on ga (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_armor_text_color_ga_normal": {
+      "desc": "Text color for ga (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_armor_text_color_ya_low": {
+      "desc": "Text color when low on ya (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_armor_text_color_ya_normal": {
+      "desc": "Text color for ya (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_armor_text_color_ra_low": {
+      "desc": "Text color when low on ra (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_armor_text_color_ra_normal": {
+      "desc": "Text color for ra (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
     "hud_armordamage_align": {
       "desc": "Sets armordamage HUD element alignment.",
       "group-id": "19",

--- a/help_variables.json
+++ b/help_variables.json
@@ -9542,6 +9542,21 @@
       "group-id": "19",
       "type": "float"
     },
+    "hud_health_text_color_low": {
+      "desc": "Text color when low on health (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_health_text_color_normal": {
+      "desc": "Text color when health is normal (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
+    "hud_health_text_color_mega": {
+      "desc": "Text color when having mega healt (only used with style 1 or 3, format: 0-255 0-255 0-255)",
+      "group-id": "19",
+      "type": "string"
+    },
     "hud_healthdamage_align": {
       "desc": "Sets healthdamage HUD element alignment.",
       "group-id": "19",

--- a/src/hud_armor.c
+++ b/src/hud_armor.c
@@ -54,9 +54,14 @@ static qbool HUD_ArmorLow(void)
 
 static void SCR_HUD_DrawArmor(hud_t *hud)
 {
-	int level;
+	int level, stats;
 	qbool low;
 	static cvar_t *scale = NULL, *style, *digits, *align, *pent_666, *proportional, *hidezero;
+	static cvar_t *text_color_none;
+	static cvar_t *text_color_ga_low, *text_color_ga_normal;
+	static cvar_t *text_color_ya_low, *text_color_ya_normal;
+	static cvar_t *text_color_ra_low, *text_color_ra_normal;
+	byte *text_color = NULL, *text_color_low = NULL;
 
 	if (scale == NULL) {
 		// first time called
@@ -67,6 +72,13 @@ static void SCR_HUD_DrawArmor(hud_t *hud)
 		pent_666 = HUD_FindVar(hud, "pent_666"); // Show 666 or armor value when carrying pentagram
 		proportional = HUD_FindVar(hud, "proportional");
 		hidezero = HUD_FindVar(hud, "hidezero"); //Hide armor number if zero
+		text_color_none = HUD_FindInitTextColorVar(hud, "text_color_none");
+		text_color_ga_low = HUD_FindInitTextColorVar(hud, "text_color_ga_low");
+		text_color_ga_normal = HUD_FindInitTextColorVar(hud, "text_color_ga_normal");
+		text_color_ya_low = HUD_FindInitTextColorVar(hud, "text_color_ya_low");
+		text_color_ya_normal = HUD_FindInitTextColorVar(hud, "text_color_ya_normal");
+		text_color_ra_low = HUD_FindInitTextColorVar(hud, "text_color_ra_low");
+		text_color_ra_normal = HUD_FindInitTextColorVar(hud, "text_color_ra_normal");
 	}
 
 	if (HUD_Stats(STAT_HEALTH) > 0) {
@@ -85,7 +97,38 @@ static void SCR_HUD_DrawArmor(hud_t *hud)
 	}
 	if (level == 0 && hidezero->integer == 1) return;
 	if (cl.spectator == cl.autocam) {
-		SCR_HUD_DrawNum(hud, level, low, scale->value, style->value, digits->value, align->string, proportional->integer);
+		stats = HUD_Stats(STAT_ITEMS);
+
+		if ((stats & IT_ARMOR1)) {
+			text_color = strlen(text_color_ga_normal->string) > 0
+				? text_color_ga_normal->color
+				: NULL;
+			text_color_low = strlen(text_color_ga_low->string) > 0
+				? text_color_ga_low->color
+				: NULL;
+		} else if ((stats & IT_ARMOR2)) {
+			text_color = strlen(text_color_ya_normal->string) > 0
+				? text_color_ya_normal->color
+				: NULL;
+			text_color_low = strlen(text_color_ya_low->string) > 0
+				? text_color_ya_low->color
+				: NULL;
+		} else if ((stats & IT_ARMOR3)) {
+			text_color = strlen(text_color_ra_normal->string) > 0
+				? text_color_ra_normal->color
+				: NULL;
+			text_color_low = strlen(text_color_ra_low->string) > 0
+				? text_color_ra_low->color
+				: NULL;
+		} else if (strlen(text_color_none->string) > 0) {
+			text_color = text_color_none->color;
+			text_color_low = text_color_none->color;
+		}
+
+		SCR_HUD_DrawNum2(hud, level, low,
+			scale->value, style->value, digits->value, align->string,
+			proportional->integer, true,
+			text_color_low, text_color);
 	}
 }
 
@@ -237,6 +280,13 @@ void Armor_HudInit(void)
 		"pent_666", "1",  // Show 666 instead of armor value
 		"proportional", "0",
 		"hidezero", "0", // Hide armor number if 0
+		"text_color_none", "",
+		"text_color_ga_low", "",
+		"text_color_ga_normal", "",
+		"text_color_ya_low", "",
+		"text_color_ya_normal", "",
+		"text_color_ra_low", "",
+		"text_color_ra_normal", "",
 		NULL
 	);
 

--- a/src/hud_health.c
+++ b/src/hud_health.c
@@ -44,6 +44,7 @@ static qbool HUD_HealthLow(void)
 static void SCR_HUD_DrawHealth(hud_t *hud)
 {
 	static cvar_t *scale = NULL, *style, *digits, *align, *proportional;
+	static cvar_t *text_color_low, *text_color_normal, *text_color_mega;
 	static int value;
 	if (scale == NULL) {
 		// first time called
@@ -52,11 +53,20 @@ static void SCR_HUD_DrawHealth(hud_t *hud)
 		digits = HUD_FindVar(hud, "digits");
 		align = HUD_FindVar(hud, "align");
 		proportional = HUD_FindVar(hud, "proportional");
+		text_color_low = HUD_FindInitTextColorVar(hud, "text_color_low");
+		text_color_normal = HUD_FindInitTextColorVar(hud, "text_color_normal");
+		text_color_mega = HUD_FindInitTextColorVar(hud, "text_color_mega");
 	}
 
 	value = HUD_Stats(STAT_HEALTH);
 	if (cl.spectator == cl.autocam) {
-		SCR_HUD_DrawNum(hud, (value < 0 ? 0 : value), HUD_HealthLow(), scale->value, style->value, digits->value, align->string, proportional->integer);
+		SCR_HUD_DrawNum2(hud, (value < 0 ? 0 : value), HUD_HealthLow(),
+			scale->value, style->value, digits->value, align->string,
+			proportional->integer, true,
+			strlen(text_color_low->string) == 0 ? NULL : text_color_low->color,
+			value > 100
+				? strlen(text_color_mega->string) == 0 ? NULL : text_color_mega->color
+				: strlen(text_color_normal->string) == 0 ? NULL : text_color_normal->color);
 	}
 }
 
@@ -141,6 +151,9 @@ void Health_HudInit(void)
 		"align", "right",
 		"digits", "3",
 		"proportional", "0",
+		"text_color_low", "",
+		"text_color_normal", "",
+		"text_color_mega", "",
 		NULL
 	);
 


### PR DESCRIPTION
Customization of the armor and health text colors in the hud.

New variables:
- hud_armor_text_color_none
- hud_armor_text_color_ga_low
- hud_armor_text_color_ga_normal
- hud_armor_text_color_ya_low
- hud_armor_text_color_ya_normal
- hud_armor_text_color_ra_low
- hud_armor_text_color_ra_normal
- hud_health_text_color_low
- hud_health_text_color_normal
- hud_health_text_color_mega

Screenshot:
![armor_health_colors](https://github.com/user-attachments/assets/ae4ff47d-d819-4385-9a92-566854595455)

Feature requested by Xerial
