### PR TITLE
MENU: add Slime's revived new-old player skin colors

### DIFF
--- a/src/settings.h
+++ b/src/settings.h
@@ -65,7 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define ADDSET_NAMED(label, var, strs) { stt_named, label, false, &var, 0, sizeof(strs)/sizeof(char*)-1, 1, NULL, NULL, NULL, strs }
 
 // color
-#define ADDSET_COLOR(label, var) { stt_playercolor, label, false, &var, -1, 13, 1, NULL, NULL, NULL, NULL }
+#define ADDSET_COLOR(label, var) { stt_playercolor, label, false, &var, -1, 16, 1, NULL, NULL, NULL, NULL }
 
 // key bind
 #define ADDSET_BIND(label, cmd) { stt_bind, label, false, NULL, 0, 0, 0, NULL, NULL, NULL, NULL, cmd }
@@ -101,7 +101,7 @@ typedef enum  {
 	stt_enum,                  // named enum, pairs of "name", "value"
 	stt_action,                // function is assigned to this, pointer must be stored in togglefnc
 	stt_string,                // string - fully editable by the user, needs only cvar
-	stt_playercolor,           // named enum 0..13
+	stt_playercolor,           // named enum 0..16
 	stt_skin,                  // player skin
 	stt_bind,                  // keybinding
 	stt_advmark,               // denotes advanced settings area

--- a/src/settings_page.c
+++ b/src/settings_page.c
@@ -57,7 +57,7 @@ filelist_t skins_filelist;
 
 static float SliderPos(float min, float max, float val) { return (val-min)/(max-min); }
 
-static const char* colors[14] = { "White", "Brown", "Lavender", "Khaki", "Red", "Lt Brown", "Peach", "Lt Peach", "Purple", "Dk Purple", "Tan", "Green", "Yellow", "Blue" };
+static const char* colors[17] = { "White", "Brown", "Lavender", "Khaki", "Red", "Light Brown", "Peach", "Light Peach", "Purple", "Dark Purple", "Tan", "Green", "Yellow", "Blue", "Orange", "Bright Red", "Black"};
 #define COLORNAME(x) colors[bound(0, ((int) x), sizeof(colors) / sizeof(char*) - 1)]
 
 char* SettingColorName(int color)


### PR DESCRIPTION
14/15/16 could be displayed but not selected and were not named correctly.
Added Orange, Bright Red, Black and resized enum to fit.