### PR TITLE
MENU: Add 48kHz to sample rate selector on Windows

### DIFF
--- a/src/menu_options.c
+++ b/src/menu_options.c
@@ -237,7 +237,8 @@ const char* scr_conback_enum[] = {
 
 const char* s_khz_enum[] = {
 	"11 kHz", "11", "22 kHz", "22", "44 kHz", "44"
-#if defined(__linux__) || defined(__FreeBSD__)
+//FIXME probably works on all supported platforms by now?
+#if defined(__linux__) || defined(__FreeBSD__) || defined(_WIN32)
 	,"48 kHz", "48"
 #endif
 };


### PR DESCRIPTION
Win can already use s_khz 48 but the enum in the menu had it behind an ifdef for linux+freebsd.
Might want to get rid of the ifdef altogether at a later date, assuming it also works on macOS (what else would there be?).