### PR TITLE
CON: use alpha in scr_conpicture if available

### DIFF
--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -1038,7 +1038,7 @@ void Draw_InitConback(void)
 		Sys_Error("Draw_InitConback: conback.lmp size is not 320x200");
 	}
 
-	if ((pic_24bit = R_LoadPicImage(va("gfx/%s", scr_conpicture.string), "conback", 0, 0, 0))) {
+	if ((pic_24bit = R_LoadPicImage(va("gfx/%s", scr_conpicture.string), "conback", 0, 0, TEX_ALPHA))) {
 		Draw_CopyMPICKeepSize(&conback, pic_24bit);
 	}
 	else {


### PR DESCRIPTION
Gives artists more options for transparency effects in the console background. Blends with scr_conalpha.
No change in behaviour when the image has no alpha: the image loading routine knows what to do.

Adresses https://github.com/QW-Group/ezquake-source/issues/1029