### PR TITLE
iDrive 2

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1752,18 +1752,22 @@
     },
     "cl_iDrive": {
       "default": "0",
-      "desc": "Emulates \"strafe script\". When turned on, you will always change direction instead of stopping when holding opposing movement keys +moveleft and +moveright, or +forward and +back.",
+      "desc": "Emulates \"strafe script\". Mode 1 instantly changes direction when holding opposing movement keys +moveleft and +moveright, or +forward and +back. Mode 2 adds a neutral frame before switching directions to smooth model movement.",
       "group-id": "9",
       "remarks": "Reported in your f_ruleset reply with the '+i' flag.\nCan not be changed during a match.",
-      "type": "boolean",
+      "type": "integer",
       "values": [
         {
           "description": "Pressing keys for both directions will stop movement on that axis.",
-          "name": "false"
+          "name": "0"
         },
         {
           "description": "Auto-releases one of the keys when both directions are pressed.",
-          "name": "true"
+          "name": "1"
+        },
+        {
+          "description": "Adds a neutral frame between opposite directions to improve smoothness.",
+          "name": "2"
         }
       ]
     },

--- a/src/cl_input.c
+++ b/src/cl_input.c
@@ -755,6 +755,7 @@ void CL_BaseMove(usercmd_t* cmd)
 	float forwardspeed = (float)fabs(cl_forwardspeed.value);
 	float backspeed = (float)fabs(cl_backspeed.value);
 	float speedmodifier = (float)fabs(cl_movespeedkey.value);
+	int idrive = cl_iDrive.integer;
 
 	CL_AdjustAngles();
 
@@ -762,7 +763,7 @@ void CL_BaseMove(usercmd_t* cmd)
 
 	VectorCopy(cl.viewangles, cmd->angles);
 
-	if (cl_iDrive.integer) {
+	if (idrive) {
 		float s1, s2;
 
 		if (in_strafe.state & 1) {
@@ -793,6 +794,13 @@ void CL_BaseMove(usercmd_t* cmd)
 		cmd->sidemove += sidespeed * s1;
 		cmd->sidemove -= sidespeed * s2;
 
+		if ((idrive == 2) && !(s1 && s2) && (s1 || s2) && cls.sidemove_prev) {
+			if (cls.sidemove_prev != (cmd->sidemove > 0) - (cmd->sidemove < 0)) {
+				cmd->sidemove -= sidespeed * s1;
+				cmd->sidemove += sidespeed * s2;
+			}
+		}
+
 		s1 = CL_KeyState(&in_up, false);
 		s2 = CL_KeyState(&in_down, false);
 
@@ -819,6 +827,13 @@ void CL_BaseMove(usercmd_t* cmd)
 
 			cmd->forwardmove += forwardspeed * s1;
 			cmd->forwardmove -= backspeed * s2;
+
+			if ((idrive == 2) && !(s1 && s2) && (s1 || s2) && cls.forwardmove_prev) {
+				if (cls.forwardmove_prev != (cmd->forwardmove > 0) - (cmd->forwardmove < 0)) {
+					cmd->forwardmove -= forwardspeed * s1;
+					cmd->forwardmove += backspeed * s2;
+				}
+			}
 		}
 	}
 	else {
@@ -844,6 +859,15 @@ void CL_BaseMove(usercmd_t* cmd)
 		cmd->forwardmove *= speedmodifier;
 		cmd->sidemove *= speedmodifier;
 		cmd->upmove *= speedmodifier;
+	}
+
+	if (idrive == 2) {
+		cls.sidemove_prev = (cmd->sidemove > 0) - (cmd->sidemove < 0);
+		cls.forwardmove_prev = (cmd->forwardmove > 0) - (cmd->forwardmove < 0);
+	}
+	else {
+		cls.sidemove_prev = 0;
+		cls.forwardmove_prev = 0;
 	}
 
 #ifdef JSS_CAM

--- a/src/client.h
+++ b/src/client.h
@@ -416,6 +416,9 @@ typedef struct
 	byte		cmdmsg_data[1024];		///< have no idea which size here must be
 	sizebuf_t	cmdmsg;
 
+	int		sidemove_prev;		///< previous frame sidemove direction for cl_iDrive 2
+	int		forwardmove_prev;	///< previous frame forwardmove direction for cl_iDrive 2
+
 	// TCPCONNECT
 	int			sockettcp;
 	netadr_t	sockettcpdest;

--- a/src/rulesets.c
+++ b/src/rulesets.c
@@ -763,24 +763,36 @@ void Rulesets_OnChange_cl_iDrive(cvar_t *var, char *value, qbool *cancel)
 		return;
 	}
 
-	if (fval != 0 && fval != 1) {
-		Com_Printf("Invalid value for %s, use 0 or 1.\n", var->name);
-		*cancel = true;
-		return;
+	if (fval != 0 && fval != 1 && fval != 2) {
+			Com_Printf("Invalid value for %s, use 0, 1 or 2.\n", var->name);
+			*cancel = true;
+			return;
 	}
 
 	if (cls.state == ca_active) {
 		if (cl.standby) {
 			// allow in standby
-			Cbuf_AddText(va("say side step aid (strafescript): %s\n", ival ? "on" : "off"));
+			const char *state;
+
+			if (!ival) {
+					state = "off";
+			}
+			else if (ival == 1) {
+					state = "on";
+			}
+			else {
+					state = "smooth";
+			}
+
+			Cbuf_AddText(va("say side step aid (strafescript): %s\n", state));
 		}
 		else {
-			// disallow during the match
-			Com_Printf("%s changes are not allowed during the match\n", var->name);
-			*cancel = true;
+				// disallow during the match
+		Com_Printf("%s changes are not allowed during the match\n", var->name);
+		*cancel = true;
 		}
 	} else {
-		// allow in not fully connected state
+	// allow in not fully connected state
 	}
 }
 


### PR DESCRIPTION
iDrive 2 is designed for players who previously used the Last Input Priority SOCD cleaning behavior. Unlike that mode, iDrive 2 inserts a neutral frame between opposing directional inputs. This results in smoother player movement and slightly reduces the speed gain compared to iDrive 1. While iDrive 2 still provides a competitive advantage, the effect is less noticeable.