### PR TITLE
fontload: switch every proportional-font cvar at once

### DIFF
--- a/src/fonts.c
+++ b/src/fonts.c
@@ -405,6 +405,83 @@ int FontFixedWidth(int max_length, float scale, qbool digits_only, qbool proport
 	return ceil((digits_only ? max_num_glyph_width : max_glyph_width) * max_length * scale);
 }
 
+// Remembers the previous value of every "*_proportional" cvar (console, scoreboard, HUD
+// elements, ...) the first time "fontload" switches them all to proportional, so that
+// "fontload none" can restore each one to what the user had before instead of zeroing
+// everything - a config with some elements deliberately left non-proportional (fixed-width
+// frag counters etc) survives a fontload/fontload-none round trip unchanged.
+typedef struct proportional_snapshot_s {
+	struct proportional_snapshot_s* next;
+	cvar_t* var;
+	char* value;
+} proportional_snapshot_t;
+
+static proportional_snapshot_t* proportional_snapshot;
+static qbool proportional_snapshot_taken;
+
+static void Font_TakeProportionalSnapshot(void)
+{
+	cvar_t* var;
+	size_t suffix_len = strlen("_proportional");
+
+	if (proportional_snapshot_taken) {
+		return;
+	}
+	proportional_snapshot_taken = true;
+
+	for (var = Cvar_Next(NULL); var; var = Cvar_Next(var)) {
+		size_t name_len = strlen(var->name);
+
+		if (name_len >= suffix_len && !strcmp(var->name + name_len - suffix_len, "_proportional")) {
+			proportional_snapshot_t* entry = Q_malloc(sizeof(*entry));
+
+			entry->var = var;
+			entry->value = Q_strdup(var->string);
+			entry->next = proportional_snapshot;
+			proportional_snapshot = entry;
+		}
+	}
+}
+
+// Switches every "*_proportional" cvar to proportional mode. Only called from the
+// "fontload <path>" command itself (not from font_facepath's OnChange), so that loading
+// a config file ("exec"/"set font_facepath ...") never has this mass side-effect - only
+// explicitly typing "fontload" does.
+static int Font_EnableAllProportional(void)
+{
+	proportional_snapshot_t* entry;
+	int count = 0;
+
+	Font_TakeProportionalSnapshot();
+
+	for (entry = proportional_snapshot; entry; entry = entry->next) {
+		Cvar_Set(entry->var, "1");
+		count++;
+	}
+
+	return count;
+}
+
+// Restores every "*_proportional" cvar to whatever value it had before the first
+// "fontload" of the session touched it (falls back to "0" if no snapshot was ever taken,
+// e.g. "fontload none" with nothing loaded yet).
+static int Font_RestoreAllProportional(void)
+{
+	proportional_snapshot_t* entry;
+	int count = 0;
+
+	if (!proportional_snapshot_taken) {
+		return 0;
+	}
+
+	for (entry = proportional_snapshot; entry; entry = entry->next) {
+		Cvar_Set(entry->var, entry->value);
+		count++;
+	}
+
+	return count;
+}
+
 static void OnChange_font_facepath(cvar_t* cvar, char* newvalue, qbool* cancel)
 {
 	if (newvalue && !newvalue[0]) {
@@ -412,7 +489,7 @@ static void OnChange_font_facepath(cvar_t* cvar, char* newvalue, qbool* cancel)
 		*cancel = false;
 	}
 	else {
-		*cancel = !FontCreate(0, Cmd_Argv(1));
+		*cancel = !FontCreate(0, newvalue);
 	}
 }
 
@@ -430,10 +507,19 @@ void Draw_LoadFont_f(void)
 		break;
 	case 2:
 		if (!strcmp(Cmd_Argv(1), "none")) {
-			Cvar_Set(&font_facepath, "");
+			if (font_facepath.string[0]) {
+				Cvar_Set(&font_facepath, "");
+				Com_Printf("Proportional font cleared, restored %d \"*_proportional\" cvar(s) to their previous value\n", Font_RestoreAllProportional());
+			}
 		}
 		else {
-			Cvar_Set(&font_facepath, Cmd_Argv(1));
+			char requested[MAX_OSPATH];
+
+			strlcpy(requested, Cmd_Argv(1), sizeof(requested));
+			Cvar_Set(&font_facepath, requested);
+			if (!strcmp(font_facepath.string, requested)) {
+				Com_Printf("Proportional font \"%s\" loaded, switched %d \"*_proportional\" cvar(s) to use it (\"%s none\" reverts)\n", requested, Font_EnableAllProportional(), Cmd_Argv(0));
+			}
 		}
 		break;
 	default:


### PR DESCRIPTION
## 🎯 Problem

ezQuake can already render the console, scoreboard and HUD with a custom `.ttf`/`.otf` font loaded via FreeType instead of the classic bitmap charset. `fontload <file>` loads the font asset correctly — but that alone doesn't make anything *use* it.

Actually switching the whole interface over to it requires manually setting **70 separate `*_proportional` cvars** one by one:

- 7 standalone cvars — `con_proportional`, `scr_damage_proportional`, `scr_autoid_proportional`, `scr_shownick_proportional`, `scr_teaminfo_proportional`, `scr_scoreboard_proportional`, `r_tracker_proportional`
- 63 more, one per HUD element, created dynamically by `HUD_Register()` as `hud_<element>_proportional` — ammo, armor, clock, frags, gun, health, items, net, fps/frametime/framestats, radar, scores, speed, teaminfo, tracking, weaponstats, and so on

If a player loads a font and misses even one of these, that specific piece of the screen stays stuck on the old bitmap charset while everything else has switched — in practice this is exactly what happens: fps/frametime counters, frag counts, and other elements silently keep the classic charset because their specific cvar was never part of whatever list a player copy-pasted from a wiki/config.

There's no "switch everything at once" command for this today. It doesn't make sense to expect a player to run 70 individual `set hud_x_proportional 1` commands just to use a font they already loaded — the command that loads the font is the one place that should already know what to do with it, the same way switching back to the bitmap charset is already a single, complete operation.

## ✅ Fix

`fontload <file>` now does the complete job:

- 🔤 On a **successful** load, it walks every registered cvar whose name ends in `_proportional` (via `Cvar_Next`, no hardcoded list — stays correct as new HUD elements get added in the future) and switches it to `1`. Nothing is touched if the load fails (ruleset restriction mid-match, missing file, missing freetype library, ...).
- ↩️ `fontload none` reverts those same cvars — **not to a hardcoded `0`**, but to whatever value each one had *before* the first successful `fontload` this session. A config that deliberately keeps some elements non-proportional (e.g. fixed-width frag counters, which some players prefer for readability) survives a `fontload` / `fontload none` round trip unchanged.
- 🧠 The snapshot is taken once per session (on the first successful load) and reused by later `fontload` calls, so switching between two custom fonts doesn't re-snapshot an already-modified state.
- 🔒 **Scope is intentionally narrow**: the mass switch only happens when `fontload` is invoked directly, from the console. Setting `font_facepath` through any other path (`set font_facepath ...`, or loading it back from a saved `.cfg` via `exec`) does **not** trigger it — config files remain a complete, self-contained description of cvar state, and `fontload` stays a convenience layered on top, not a hidden side effect baked into the cvar itself.
- 🐛 Fixed a small pre-existing bug in `OnChange_font_facepath()` while touching this code: it read the new value via `Cmd_Argv(1)` instead of the `newvalue` parameter the callback already receives. This happened to work when the cvar was changed by literally typing `fontload <file>` (where `Cmd_Argv(1)` coincides with the new value), but silently read the wrong value on any other path that sets the cvar — which the fix above now relies on being correct.

### 📋 What changed, line by line

Everything lives in `src/fonts.c`, nothing else is touched.

**1. `OnChange_font_facepath()` — one-line bugfix**

```diff
  else {
-     *cancel = !FontCreate(0, Cmd_Argv(1));
+     *cancel = !FontCreate(0, newvalue);
  }
```
Uses the value the callback actually received instead of re-reading console argv, which is only correct by coincidence when called from `fontload`.

**2. Three new small static functions** — `Font_TakeProportionalSnapshot()`, `Font_EnableAllProportional()`, `Font_RestoreAllProportional()`. Self-contained, only touch `cvar_t` pointers already reachable via the public `Cvar_Next()` API. No new global state visible outside this file.

**3. `Draw_LoadFont_f()` — the `fontload` command itself**

```diff
  case 2:
      if (!strcmp(Cmd_Argv(1), "none")) {
-         Cvar_Set(&font_facepath, "");
+         if (font_facepath.string[0]) {
+             Cvar_Set(&font_facepath, "");
+             Com_Printf("Proportional font cleared, restored %d \"*_proportional\" cvar(s) to their previous value\n", Font_RestoreAllProportional());
+         }
      }
      else {
-         Cvar_Set(&font_facepath, Cmd_Argv(1));
+         char requested[MAX_OSPATH];
+
+         strlcpy(requested, Cmd_Argv(1), sizeof(requested));
+         Cvar_Set(&font_facepath, requested);
+         if (!strcmp(font_facepath.string, requested)) {
+             Com_Printf("Proportional font \"%s\" loaded, switched %d \"*_proportional\" cvar(s) to use it (\"%s none\" reverts)\n", requested, Font_EnableAllProportional(), Cmd_Argv(0));
+         }
      }
      break;
```
`requested` is copied to a local buffer before the 70 `Cvar_Set()` calls run, since `Cmd_Argv()` points at a reusable buffer that could otherwise be invalidated mid-loop. Success is checked by comparing `font_facepath.string` against what was actually requested — `Cvar_SetEx()` leaves the cvar untouched when `OnChange` cancels the change, so this correctly detects a rejected load instead of assuming success from a non-empty string.

### 🎮 Before / after

```
] fontload myfont.otf
Proportional font "myfont.otf" loaded
] set hud_fps_proportional 1
] set hud_frags_proportional 1
] set hud_frametime_proportional 1
] ... (66 more, hoping none were forgotten)
```

```
] fontload myfont.otf
Proportional font "myfont.otf" loaded, switched 70 "*_proportional" cvar(s) to use it ("fontload none" reverts)
] fontload none
Proportional font cleared, restored 70 "*_proportional" cvar(s) to their previous value
```

## 🧩 Not in scope

Two gaps exist and are intentionally left alone, since they'd need actual code changes rather than a cvar sweep:

- **Menu screens** have no proportional-font support at all — zero `*_proportional` references anywhere in that code path.
- **HUD editor** draws its own labels/text directly, with no proportional cvar consulted.

Both are configuration/editing screens outside of actual gameplay, so this is a known, accepted limitation rather than something this PR attempts to fix.

## 💡 Spoike's per-element font idea — investigated, deliberately out of scope here

Spoike raised two related points worth addressing explicitly:

1. Wouldn't it be nicer if elements just used whichever font is actually loaded, without needing a per-element `_proportional` cvar to opt in at all?
2. Taking that further: instead of proportional-or-not, why not let each element pick *which* font to use — e.g. Courier for the console, Comic Sans for autoid — falling back to the default/classic charset when unset?

Both are the right direction long-term, and worth pursuing. I looked into what implementing #2 (which subsumes #1) would actually take, since it changes whether this small PR is still worth merging on its own:

- `proportional_fonts[MAX_CHARSETS]` (`fonts.c:58`) looks at first glance like it already supports multiple simultaneous fonts (256 slots), but it doesn't in practice: glyph metrics (`glyphs[4096]`, `max_glyph_width`, `max_num_glyph_width`) are module-level globals, not per-slot, and `FontCreate()` `memset`s them on every call — loading a second font today would corrupt the spacing of the first. Worse, the 256-slot index is already spoken for: `r_draw_charset.c` uses it as the wide-char charset page (`(ch >> 8) & 0xFF`), not "which font". Real multi-font support needs a second dimension (`[font][charset]`) touching `fonts.c`, `r_atlas.c`, and `r_draw_charset.c`, plus a VRAM budget (each loaded face is a 2048×2048 atlas).
- Every read site that currently takes a `qbool proportional` — 89 function signatures across 27 files, ~104 call sites — would need to resolve a font selection instead of a bool. Mechanical in places, but the metrics/indexing issues above make this an architectural change, not a refactor.

So: real work, real value, but a different, larger PR — not something to bundle into a cvar-sweep fix. This PR stays deliberately small and unblocked by that design discussion. It's also forward-compatible with it: the snapshot/restore logic here is self-contained in `fonts.c` and doesn't touch any of those 89 read sites, so if/when per-element fonts land, this same mechanism becomes the compatibility shim for existing configs (`hud_x_proportional 1` → `hud_x_font <default>`) rather than needing to be ripped out.

## 🔍 Testing

- Built this exact branch clean (MSVC 19.44 / Ninja, `RelWithDebInfo`, FreeType enabled) and ran it against `id1/pak0.pak`+`pak1.pak` with a real `.ttf` (`cour.ttf`) dropped into `qw/fonts/`.
- **`fontload cour.ttf`** (console output, verbatim from `qconsole.log`):
  ```
  Proportional font "cour.ttf" loaded, switched 70 "*_proportional" cvar(s) to use it ("fontload none" reverts)
  ```
- Queried individual cvars afterwards to confirm they actually flipped, not just that a count was printed:
  ```
  con_proportional : default value is "0"       current value is "1"
  hud_fps_proportional : default value is "0"    current value is "1"
  hud_frags_proportional : default value is "0"  current value is "1"
  ```
  (`hud_fps_proportional` and `hud_frags_proportional` specifically because those were the two elements that used to get missed by hand — they're what motivated this fix.)
- **`fontload none`** afterwards:
  ```
  Proportional font cleared, restored 70 "*_proportional" cvar(s) to their previous value
  ```
- **`fontload cour.otf`** (file that doesn't exist, to check the failure path):
  ```
  Font file could not be opened
  ```
  and correctly printed no "switched N cvar(s)" line — confirms nothing gets touched on a failed load, so a rejected `fontload` never leaves the HUD in a proportional-but-no-font-loaded state.
- Also verified the 70-cvar count itself directly against this source tree by running `cvarlist_re _proportional$` in-game (listed all 70 by name) and cross-checking against the source (7 standalone `cvar_t` declarations + 63 registered dynamically via `HUD_Register`).

## 📁 Files changed

- `src/fonts.c` only — no other file is touched.
