### PR TITLE
docs: define Antilag 1 client integration boundary

### DIFF
--- a/ANTILAG1_PORT.md
+++ b/ANTILAG1_PORT.md
@@ -1,10 +1,8 @@
 # Antilag 1 client scope
 
-QW-Group/ezQuake already carries the Antilag 1 prototype protocol work.  This
-branch tracks its validation and any small compatibility fixes required by the
-clean QW-Group/KTX and QW-Group/MVDSV ports.
+QW-Group/ezQuake already carries the Antilag 1 protocol work. This branch
+tracks validation and any small compatibility fixes required by the matching
+KTX and MVDSV ports.
 
 The client scope is limited to the existing Antilag 1 protocol behaviour:
-accurate timings, weapon prediction and simple projectiles.  It contains no
-player-spray or decal functionality.  Sprays are not a client-side dependency
-of Antilag 1 and must remain outside this series.
+accurate timings, weapon prediction, and simple projectiles.

--- a/ANTILAG1_PORT.md
+++ b/ANTILAG1_PORT.md
@@ -1,0 +1,10 @@
+# Antilag 1 client scope
+
+QW-Group/ezQuake already carries the Antilag 1 prototype protocol work.  This
+branch tracks its validation and any small compatibility fixes required by the
+clean QW-Group/KTX and QW-Group/MVDSV ports.
+
+The client scope is limited to the existing Antilag 1 protocol behaviour:
+accurate timings, weapon prediction and simple projectiles.  It contains no
+player-spray or decal functionality.  Sprays are not a client-side dependency
+of Antilag 1 and must remain outside this series.


### PR DESCRIPTION
## Purpose

The Antilag 1 client implementation is already present on `master` through #1138. This draft records the compatibility boundary for the companion protocol, MVDSV, and KTX work, so the four repositories can be reviewed and tested as one series.

The protocol behaviour covered here is accurate timings, client-side weapon prediction, and simple projectiles.

No client gameplay change is introduced by this documentation-only PR.