### PR TITLE
Integrate qwfwd mesh routes into sb_findroutes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,6 +665,7 @@ set(client
         ${SOURCE_DIR}/cl_cam.c
         ${SOURCE_DIR}/cl_cmd.c
         ${SOURCE_DIR}/cl_demo.c
+        ${SOURCE_DIR}/cl_connectbr.c
         ${SOURCE_DIR}/cl_ents.c
         ${SOURCE_DIR}/cl_input.c
         ${SOURCE_DIR}/cl_main.c

--- a/src/EX_browser.c
+++ b/src/EX_browser.c
@@ -539,6 +539,7 @@ void Serverinfo_Rules_Key(int key);
 void Serverinfo_Sources_Key(int key);
 void Serverinfo_Route_Key(int key);
 void Serverinfo_Route_Invalidate(void);
+static void Serverinfo_Route_Reset(void);
 
 //
 // serverinfo
@@ -629,6 +630,7 @@ static netadr_t serverinfo_routes_addr;
 static double serverinfo_routes_built_at; // 0 means "never queried yet", even if the query found zero routes
 static qbool serverinfo_route_hop_enabled[SERVERINFO_ROUTE_MAX_HOPS];
 static int serverinfo_route_hop_enabled_for; // serverinfo_route_pos the array above belongs to, -1 if stale
+static double serverinfo_route_last_build_attempt; // Sys_DoubleTime() of the last SB_PingTree_Build() we triggered, 0 if none yet
 
 void Serverinfo_Stop(void)
 {
@@ -644,7 +646,7 @@ void Serverinfo_Start (server_data *s)
 
 	serverinfo_players_pos = 0;
 	serverinfo_sources_pos = 0;
-	Serverinfo_Route_Invalidate();
+	Serverinfo_Route_Reset();
 
 	autoupdate_serverinfo = 1;
 	show_serverinfo = s;
@@ -675,7 +677,7 @@ void Serverinfo_Change (server_data *s)
 {
 	Alter_Autoupdate(s);
 	show_serverinfo = s;
-	Serverinfo_Route_Invalidate();
+	Serverinfo_Route_Reset();
 
 	// testing connection
 	if (testing_connection)
@@ -1616,6 +1618,16 @@ void Serverinfo_Route_Invalidate(void)
 	serverinfo_route_hop_enabled_for = -1;
 }
 
+// Only called when the server the popup is showing actually changes
+// (Serverinfo_Start/Serverinfo_Change) - unlike Invalidate() this also drops
+// the SB_PingTree_Build() retry cooldown, since a genuinely different server
+// deserves an immediate fresh attempt.
+static void Serverinfo_Route_Reset(void)
+{
+	Serverinfo_Route_Invalidate();
+	serverinfo_route_last_build_attempt = 0;
+}
+
 // Rebuilds the cached route list for show_serverinfo if it is missing, for
 // the wrong server, or older than the same TTL connectbr/connectnext use
 // (CONNECTBR_ROUTE_TTL in cl_connectbr.c). Called by both Draw and Key so
@@ -1636,7 +1648,16 @@ static void Serverinfo_Route_EnsureFresh(void)
 	// an aged graph is rebuilt from scratch rather than re-running Dijkstra
 	// over measurements that may no longer reflect the network.
 	if (!SB_PingTree_Built() || SB_PingTree_Age() > 120.0) {
-		SB_PingTree_Build();
+		// SB_PingTree_Build() is fire-and-forget (a detached thread flips
+		// pingtree_built once it's done); without a cooldown, a build that
+		// fails or simply takes a while gets re-triggered on every single
+		// frame this tab is drawn/keyed, spamming "Building the Ping
+		// Tree..." and starting a fresh attempt before the last one could
+		// ever finish.
+		if (Sys_DoubleTime() - serverinfo_route_last_build_attempt > 5.0) {
+			serverinfo_route_last_build_attempt = Sys_DoubleTime();
+			SB_PingTree_Build();
+		}
 		return;
 	}
 
@@ -1690,6 +1711,23 @@ static void Serverinfo_Route_ApplyToProxyaddr(void)
 	Cvar_Set(&cl_proxyaddr, out);
 }
 
+// Connects using exactly what the route tab currently has applied to
+// cl_proxyaddr (Serverinfo_Route_ApplyToProxyaddr already ran on every
+// selection/toggle). Deliberately does NOT call SB_PingTree_ConnectBestPath -
+// that recomputes cl_proxyaddr from scratch and would silently discard the
+// user's route/hop choice, which is the whole point of this tab.
+static void Serverinfo_Route_Connect(void)
+{
+	server_data *s = show_serverinfo;
+
+	if (!s)
+		return;
+	Cbuf_AddText("join ");
+	Cbuf_AddText(s->display.ip);
+	Cbuf_AddText("\n");
+	SB_Browser_Hide(s);
+}
+
 void Serverinfo_Route_Draw(int x, int y, int w, int h)
 {
 	int i, listsize, routes_shown;
@@ -1723,13 +1761,14 @@ void Serverinfo_Route_Draw(int x, int y, int w, int h)
 	if (serverinfo_route_pos < serverinfo_route_disp)
 		serverinfo_route_disp = serverinfo_route_pos;
 
-	UI_Print(x, y, " #  cost   hops (ctrl+up/down to move)", true);
+	// header/footer take one row each, so hop area gets everything between
+	UI_Print(x, y, " #  cost  hops", true);
 	for (i = 0; i < routes_shown; i++) {
-		char buf[80];
+		char buf[40];
 		int ri = serverinfo_route_disp + i;
 		sb_route_t *route = &serverinfo_routes[ri];
 
-		snprintf(buf, sizeof(buf), " %-2d %5dms %d", ri + 1, route->total_cost_ms, route->hops);
+		snprintf(buf, sizeof(buf), " %-2d %5dms  %d", ri + 1, route->total_cost_ms, route->hops);
 		buf[w/8] = 0;
 		UI_Print(x, y + i*8 + 8, buf, ri == serverinfo_route_pos);
 	}
@@ -1740,23 +1779,25 @@ void Serverinfo_Route_Draw(int x, int y, int w, int h)
 
 	hopy = y + routes_shown * 8 + 16;
 	if (!hop_count) {
-		UI_Print(x, hopy, "direct connection, no proxy hops", false);
-		return;
+		UI_Print(x, hopy, "direct, no proxy hops", false);
+	}
+	else {
+		UI_Print(x, hopy, "hops:", false);
+		hop_listsize = max(1, (y + h - (hopy + 16)) / 8);
+		hop_disp = max(0, min(serverinfo_route_hop_pos - hop_listsize + 1, hop_count - hop_listsize));
+		hop_disp = max(0, min(hop_disp, serverinfo_route_hop_pos));
+		for (i = 0; i < hop_listsize && hop_disp + i < hop_count; i++) {
+			char buf[40];
+			int hi = hop_disp + i;
+
+			snprintf(buf, sizeof(buf), " [%c] %s",
+			         serverinfo_route_hop_enabled[hi] ? 'x' : ' ', hops[hi]);
+			buf[w/8] = 0;
+			UI_Print(x, hopy + (i+1)*8, buf, hi == serverinfo_route_hop_pos);
+		}
 	}
 
-	UI_Print(x, hopy, "hops (enter to toggle):", false);
-	hop_listsize = max(1, (y + h - (hopy + 8)) / 8);
-	hop_disp = max(0, min(serverinfo_route_hop_pos - hop_listsize + 1, hop_count - hop_listsize));
-	hop_disp = max(0, min(hop_disp, serverinfo_route_hop_pos));
-	for (i = 0; i < hop_listsize && hop_disp + i < hop_count; i++) {
-		char buf[80];
-		int hi = hop_disp + i;
-
-		snprintf(buf, sizeof(buf), " [%c] %s",
-		         serverinfo_route_hop_enabled[hi] ? 'x' : ' ', hops[hi]);
-		buf[w/8] = 0;
-		UI_Print(x, hopy + (i+1)*8, buf, hi == serverinfo_route_hop_pos);
-	}
+	UI_Print(x, y + h - 8, "enter:toggle hop  j:connect", false);
 }
 
 const char *SB_Source_Type_Location_Name(sb_source_type_t type)
@@ -2431,7 +2472,10 @@ void Serverinfo_Key(int key)
 			break;
 		case 'j':
 		case 'p':
-			Join_Server(show_serverinfo);
+			if (serverinfo_pos == 3)
+				Serverinfo_Route_Connect();
+			else
+				Join_Server(show_serverinfo);
 			break;
 		case 'n':
 			Join_Server_Direct(show_serverinfo);

--- a/src/EX_browser.c
+++ b/src/EX_browser.c
@@ -532,10 +532,13 @@ void Serverinfo_Draw (void);
 void Serverinfo_Players_Draw(int x, int y, int w, int h);
 void Serverinfo_Rules_Draw(int x, int y, int w, int h);
 void Serverinfo_Sources_Draw(int x, int y, int w, int h);
+void Serverinfo_Route_Draw(int x, int y, int w, int h);
 void Serverinfo_Key (int key);
 void Serverinfo_Players_Key(int key);
 void Serverinfo_Rules_Key(int key);
 void Serverinfo_Sources_Key(int key);
+void Serverinfo_Route_Key(int key);
+void Serverinfo_Route_Invalidate(void);
 
 //
 // serverinfo
@@ -606,6 +609,27 @@ int serverinfo_sources_pos;
 int serverinfo_sources_disp;
 extern int autoupdate_serverinfo; // declared in EX_browser_net.c
 
+// serverinfo "route" tab: shows the sb_findroutes alternatives to the
+// selected server (same source/cache as the connectbr/connectinfo commands
+// in cl_connectbr.c - no separate discovery or measurement here) and lets
+// the user toggle individual proxy hops out of the selected route before
+// connecting. serverinfo_route_hop_enabled tracks hops of the CURRENTLY
+// SELECTED route only (indexed by hop position within its proxylist), so it
+// is reset every time the selected route or the underlying server changes.
+// Every hop needs at least "x:x@" (4 bytes) inside proxylist, so this many
+// hop slots can never be exceeded by a proxylist that fits in
+// SB_ROUTE_PROXYLIST_SIZE - no silent truncation of a real route.
+#define SERVERINFO_ROUTE_MAX_HOPS (SB_ROUTE_PROXYLIST_SIZE / 4)
+static sb_route_t serverinfo_routes[SB_ROUTE_MAX_ALTERNATIVES];
+static int serverinfo_routes_count;
+static int serverinfo_route_pos;
+static int serverinfo_route_disp; // route# at the top of the visible list, same role as serverinfo_sources_disp
+static int serverinfo_route_hop_pos;
+static netadr_t serverinfo_routes_addr;
+static double serverinfo_routes_built_at; // 0 means "never queried yet", even if the query found zero routes
+static qbool serverinfo_route_hop_enabled[SERVERINFO_ROUTE_MAX_HOPS];
+static int serverinfo_route_hop_enabled_for; // serverinfo_route_pos the array above belongs to, -1 if stale
+
 void Serverinfo_Stop(void)
 {
 	show_serverinfo = NULL;
@@ -620,6 +644,7 @@ void Serverinfo_Start (server_data *s)
 
 	serverinfo_players_pos = 0;
 	serverinfo_sources_pos = 0;
+	Serverinfo_Route_Invalidate();
 
 	autoupdate_serverinfo = 1;
 	show_serverinfo = s;
@@ -650,6 +675,7 @@ void Serverinfo_Change (server_data *s)
 {
 	Alter_Autoupdate(s);
 	show_serverinfo = s;
+	Serverinfo_Route_Invalidate();
 
 	// testing connection
 	if (testing_connection)
@@ -1278,13 +1304,15 @@ void Serverinfo_Draw (void)
 	buf[w/8] = 0;
 	UI_Print_Center(x, y+10, w, buf, false);
 
-	strlcpy(buf, " players serverinfo sources ", sizeof(buf));
+	strlcpy(buf, " players serverinfo sources route ", sizeof(buf));
 	if (serverinfo_pos == 0)
 		memcpy (buf, "\x10\xF0\xEC\xE1\xF9\xE5\xF2\xF3\x11", 9);
 	if (serverinfo_pos == 1)
 		memcpy (buf + 8, "\x10\xF3\xE5\xF2\xF6\xE5\xF2\xE9\xEE\xE6\xEF\x11", 12); // FIXME: non-ascii chars
 	if (serverinfo_pos == 2)
 		memcpy (buf + 19, "\x10\xF3\xEF\xF5\xF2\xE3\xE5\xF3\x11", 9); // FIXME: non-ascii chars
+	if (serverinfo_pos == 3)
+		memcpy (buf + 27, "\x10\xF2\xEF\xF5\xF4\xE5\x11", 7); // FIXME: non-ascii chars
 
 	UI_Print_Center(x, y+24, w, buf, false);
 
@@ -1306,6 +1334,8 @@ void Serverinfo_Draw (void)
 			Serverinfo_Rules_Draw(x, y+40, w, h-40); break;
 		case 2: // sources
 			Serverinfo_Sources_Draw(x, y+40, w, h-40); break;
+		case 3: // route (sb_findroutes)
+			Serverinfo_Route_Draw(x, y+40, w, h-40); break;
 		default:
 			;
 	}
@@ -1549,6 +1579,183 @@ void Serverinfo_Sources_Draw(int x, int y, int w, int h)
 
 		if (serverinfo_sources_pos == serverinfo_sources_disp+i)
 			UI_DrawCharacter(x+8*7, y+i*8+8, '\x8D');
+	}
+}
+
+// Splits route->proxylist ("ip1:port1@ip2:port2@...") into up to
+// SERVERINFO_ROUTE_MAX_HOPS null-terminated tokens written into hops[][].
+// Returns the hop count. storage must stay alive as long as hops[] is used
+// (each hops[i] points into it), so callers keep it on their own stack.
+static int Serverinfo_Route_SplitHops(const sb_route_t *route, char storage[SB_ROUTE_PROXYLIST_SIZE],
+                                       char *hops[SERVERINFO_ROUTE_MAX_HOPS])
+{
+	int count = 0;
+	char *tok, *ctx = NULL;
+
+	strlcpy(storage, route->proxylist, SB_ROUTE_PROXYLIST_SIZE);
+	if (!storage[0])
+		return 0;
+
+	for (tok = strtok_r(storage, "@", &ctx); tok && count < SERVERINFO_ROUTE_MAX_HOPS;
+	     tok = strtok_r(NULL, "@", &ctx)) {
+		hops[count++] = tok;
+	}
+	return count;
+}
+
+// Drops every cached route/hop-toggle state. Called whenever the server the
+// popup is showing changes (Serverinfo_Start/Serverinfo_Change), so the route
+// tab never shows or applies stale data left over from a different server.
+void Serverinfo_Route_Invalidate(void)
+{
+	serverinfo_routes_count = 0;
+	serverinfo_routes_built_at = 0;
+	serverinfo_route_pos = 0;
+	serverinfo_route_disp = 0;
+	serverinfo_route_hop_pos = 0;
+	serverinfo_route_hop_enabled_for = -1;
+}
+
+// Rebuilds the cached route list for show_serverinfo if it is missing, for
+// the wrong server, or older than the same TTL connectbr/connectnext use
+// (CONNECTBR_ROUTE_TTL in cl_connectbr.c). Called by both Draw and Key so
+// neither ever indexes serverinfo_routes[] against stale/foreign data.
+static void Serverinfo_Route_EnsureFresh(void)
+{
+	server_data *s = show_serverinfo;
+
+	if (s && serverinfo_routes_built_at && NET_CompareAdr(serverinfo_routes_addr, s->address)
+	    && Sys_DoubleTime() - serverinfo_routes_built_at <= 120.0)
+		return; // still fresh for the server currently shown (0 routes found is a valid, cacheable result)
+
+	Serverinfo_Route_Invalidate();
+	if (!s || SB_PingTree_IsBuilding())
+		return;
+
+	// Same staleness rule connectbr/connectnext use (CONNECTBR_ROUTE_TTL):
+	// an aged graph is rebuilt from scratch rather than re-running Dijkstra
+	// over measurements that may no longer reflect the network.
+	if (!SB_PingTree_Built() || SB_PingTree_Age() > 120.0) {
+		SB_PingTree_Build();
+		return;
+	}
+
+	serverinfo_routes_count = SB_PingTree_GetRoutes(&s->address, serverinfo_routes, SB_ROUTE_MAX_ALTERNATIVES);
+	serverinfo_routes_addr = s->address;
+	serverinfo_routes_built_at = Sys_DoubleTime();
+}
+
+// Resets the per-hop enabled flags to "all on" whenever serverinfo_route_pos
+// now points at a route serverinfo_route_hop_enabled wasn't built for
+// (route just (re)selected, or the whole cache was invalidated).
+static void Serverinfo_Route_EnsureHopState(int hop_count)
+{
+	int i;
+
+	if (serverinfo_route_hop_enabled_for == serverinfo_route_pos)
+		return;
+	for (i = 0; i < hop_count; i++)
+		serverinfo_route_hop_enabled[i] = true;
+	serverinfo_route_hop_enabled_for = serverinfo_route_pos;
+}
+
+// Rebuilds cl_proxyaddr from serverinfo_routes[serverinfo_route_pos], skipping
+// hops the user disabled with K_ENTER in the route tab. Mirrors what
+// CL_BR_ApplyRoute (cl_connectbr.c) does for connectbr/connectnext, just with
+// a user-editable hop subset instead of always using the full cached route.
+static void Serverinfo_Route_ApplyToProxyaddr(void)
+{
+	char storage[SB_ROUTE_PROXYLIST_SIZE];
+	char *hops[SERVERINFO_ROUTE_MAX_HOPS];
+	char out[SB_ROUTE_PROXYLIST_SIZE];
+	int count, i;
+
+	if (serverinfo_route_pos < 0 || serverinfo_route_pos >= serverinfo_routes_count)
+		return;
+
+	// Caller is expected to have already run EnsureHopState for this route
+	// (Draw and Key both do before calling here) - not repeated to avoid
+	// clobbering flags the caller may have just flipped.
+	count = Serverinfo_Route_SplitHops(&serverinfo_routes[serverinfo_route_pos], storage, hops);
+
+	out[0] = '\0';
+	for (i = 0; i < count; i++) {
+		if (!serverinfo_route_hop_enabled[i])
+			continue;
+		if (out[0])
+			strlcat(out, "@", sizeof(out));
+		strlcat(out, hops[i], sizeof(out));
+	}
+
+	Cvar_Set(&cl_proxyaddr, out);
+}
+
+void Serverinfo_Route_Draw(int x, int y, int w, int h)
+{
+	int i, listsize, routes_shown;
+	int hop_count, hop_disp, hop_listsize;
+	char storage[SB_ROUTE_PROXYLIST_SIZE];
+	char *hops[SERVERINFO_ROUTE_MAX_HOPS];
+	int hopy;
+
+	if (show_serverinfo == NULL)
+		return;
+
+	Serverinfo_Route_EnsureFresh();
+
+	if (!serverinfo_routes_count) {
+		UI_Print_Center(x, y + h/2 - 4, w, SB_PingTree_Built() ?
+		                "no route found by sb_findroutes" : "sb_findroutes graph not built yet", false);
+		return;
+	}
+
+	serverinfo_route_pos = max(0, min(serverinfo_route_pos, serverinfo_routes_count - 1));
+
+	// top half: route alternatives (scrolled like Serverinfo_Sources_Draw),
+	// bottom half: hops of the selected one
+	listsize = max(1, min(serverinfo_routes_count, (h/2) / 8 - 1));
+	routes_shown = min(serverinfo_routes_count, listsize);
+
+	if (serverinfo_route_pos > serverinfo_route_disp + listsize - 1)
+		serverinfo_route_disp = serverinfo_route_pos - listsize + 1;
+	if (serverinfo_route_disp > serverinfo_routes_count - listsize)
+		serverinfo_route_disp = max(serverinfo_routes_count - listsize, 0);
+	if (serverinfo_route_pos < serverinfo_route_disp)
+		serverinfo_route_disp = serverinfo_route_pos;
+
+	UI_Print(x, y, " #  cost   hops (ctrl+up/down to move)", true);
+	for (i = 0; i < routes_shown; i++) {
+		char buf[80];
+		int ri = serverinfo_route_disp + i;
+		sb_route_t *route = &serverinfo_routes[ri];
+
+		snprintf(buf, sizeof(buf), " %-2d %5dms %d", ri + 1, route->total_cost_ms, route->hops);
+		buf[w/8] = 0;
+		UI_Print(x, y + i*8 + 8, buf, ri == serverinfo_route_pos);
+	}
+
+	hop_count = Serverinfo_Route_SplitHops(&serverinfo_routes[serverinfo_route_pos], storage, hops);
+	Serverinfo_Route_EnsureHopState(hop_count);
+	serverinfo_route_hop_pos = max(0, min(serverinfo_route_hop_pos, max(0, hop_count - 1)));
+
+	hopy = y + routes_shown * 8 + 16;
+	if (!hop_count) {
+		UI_Print(x, hopy, "direct connection, no proxy hops", false);
+		return;
+	}
+
+	UI_Print(x, hopy, "hops (enter to toggle):", false);
+	hop_listsize = max(1, (y + h - (hopy + 8)) / 8);
+	hop_disp = max(0, min(serverinfo_route_hop_pos - hop_listsize + 1, hop_count - hop_listsize));
+	hop_disp = max(0, min(hop_disp, serverinfo_route_hop_pos));
+	for (i = 0; i < hop_listsize && hop_disp + i < hop_count; i++) {
+		char buf[80];
+		int hi = hop_disp + i;
+
+		snprintf(buf, sizeof(buf), " [%c] %s",
+		         serverinfo_route_hop_enabled[hi] ? 'x' : ' ', hops[hi]);
+		buf[w/8] = 0;
+		UI_Print(x, hopy + (i+1)*8, buf, hi == serverinfo_route_hop_pos);
 	}
 }
 
@@ -2183,7 +2390,11 @@ void Serverinfo_Key(int key)
 		case K_MOUSE1:
 		case 'x': // x was once used for best route connection
 		case K_ENTER:
-			if (serverinfo_pos != 2)
+			if (serverinfo_pos == 2)
+				Serverinfo_Sources_Key(key);
+			else if (serverinfo_pos == 3)
+				Serverinfo_Route_Key(key);
+			else
 			{
 				if (show_serverinfo->qwfwd) {
 					SB_Select_QWfwd(show_serverinfo);
@@ -2193,8 +2404,6 @@ void Serverinfo_Key(int key)
 					Join_Server(show_serverinfo);
 				}
 			}
-			else
-				Serverinfo_Sources_Key(key);
 			break;
 		case K_MOUSE2:
 		case K_ESCAPE:
@@ -2286,12 +2495,15 @@ void Serverinfo_Key(int key)
 				case 2: // sources
 					Serverinfo_Sources_Key(key);
 					break;
+				case 3: // route
+					Serverinfo_Route_Key(key);
+					break;
 				default:
 					;
 			}
 	}
 
-	serverinfo_pos = (serverinfo_pos + 3) % 3;
+	serverinfo_pos = (serverinfo_pos + 4) % 4;
 }
 
 void Serverinfo_Players_Key(int key)
@@ -2377,6 +2589,67 @@ void Serverinfo_Sources_Key(int key)
 
 	serverinfo_sources_pos = max(serverinfo_sources_pos, 0);
 	serverinfo_sources_pos = min(serverinfo_sources_pos, sourcesn_updated-1);
+}
+
+void Serverinfo_Route_Key(int key)
+{
+	char storage[SB_ROUTE_PROXYLIST_SIZE];
+	char *hops[SERVERINFO_ROUTE_MAX_HOPS];
+	int hop_count;
+	qbool route_changed = false;
+
+	Serverinfo_Route_EnsureFresh();
+	if (!serverinfo_routes_count)
+		return;
+	serverinfo_route_pos = max(0, min(serverinfo_route_pos, serverinfo_routes_count - 1));
+
+	hop_count = Serverinfo_Route_SplitHops(&serverinfo_routes[serverinfo_route_pos], storage, hops);
+	Serverinfo_Route_EnsureHopState(hop_count);
+	serverinfo_route_hop_pos = max(0, min(serverinfo_route_hop_pos, max(0, hop_count - 1)));
+
+	switch (key)
+	{
+		case K_UPARROW:
+		case K_MWHEELUP:
+			if (serverinfo_route_hop_pos > 0)
+				serverinfo_route_hop_pos--;
+			else if (serverinfo_route_pos > 0) {
+				serverinfo_route_pos--;
+				serverinfo_route_hop_pos = 0;
+				route_changed = true;
+			}
+			break;
+		case K_DOWNARROW:
+		case K_MWHEELDOWN:
+			if (hop_count && serverinfo_route_hop_pos < hop_count - 1)
+				serverinfo_route_hop_pos++;
+			else if (serverinfo_route_pos < serverinfo_routes_count - 1) {
+				serverinfo_route_pos++;
+				serverinfo_route_hop_pos = 0;
+				route_changed = true;
+			}
+			break;
+		case K_ENTER:
+		case K_SPACE:
+			if (hop_count && serverinfo_route_hop_pos < hop_count) {
+				serverinfo_route_hop_enabled[serverinfo_route_hop_pos] =
+					!serverinfo_route_hop_enabled[serverinfo_route_hop_pos];
+				Serverinfo_Route_ApplyToProxyaddr();
+			}
+			break;
+		default:
+			;
+	}
+
+	// Selecting a different route re-derives its own hop count/flags (they
+	// belong to the new route, not the one we just left) and applies it to
+	// cl_proxyaddr immediately - otherwise connecting without ever pressing
+	// enter/space would silently reuse whatever the previous route left set.
+	if (route_changed) {
+		hop_count = Serverinfo_Route_SplitHops(&serverinfo_routes[serverinfo_route_pos], storage, hops);
+		Serverinfo_Route_EnsureHopState(hop_count);
+		Serverinfo_Route_ApplyToProxyaddr();
+	}
 }
 
 void SB_RemoveSourceProc(void)

--- a/src/EX_browser.h
+++ b/src/EX_browser.h
@@ -292,6 +292,7 @@ void SB_PingTree_Shutdown(void);
 qbool SB_PingTree_Built(void);
 void SB_PingTree_Build(void);
 qbool SB_PingTree_IsBuilding(void);
+double SB_PingTree_Age(void);
 void SB_PingTree_DumpPath(const netadr_t *addr);
 void SB_Proxy_QueryForPingList(const netadr_t *address, proxy_ping_report_callback callback);
 void SB_PingTree_ConnectBestPath(const netadr_t *addr);

--- a/src/EX_browser.h
+++ b/src/EX_browser.h
@@ -296,6 +296,8 @@ void SB_PingTree_DumpPath(const netadr_t *addr);
 void SB_Proxy_QueryForPingList(const netadr_t *address, proxy_ping_report_callback callback);
 void SB_PingTree_ConnectBestPath(const netadr_t *addr);
 int SB_PingTree_GetPathLen(const netadr_t *addr);
+qbool SB_PingTree_GetProxyString(const netadr_t *addr, char *out, size_t outsz,
+                                  int *out_total_ping_ms);
 void SB_Proxylist_Unserialize_f(void);
 
 #define SB_TRIGGER_REFRESHDONE        1

--- a/src/EX_browser.h
+++ b/src/EX_browser.h
@@ -298,6 +298,16 @@ void SB_PingTree_ConnectBestPath(const netadr_t *addr);
 int SB_PingTree_GetPathLen(const netadr_t *addr);
 qbool SB_PingTree_GetProxyString(const netadr_t *addr, char *out, size_t outsz,
                                   int *out_total_ping_ms);
+
+#define SB_ROUTE_MAX_ALTERNATIVES 10
+#define SB_ROUTE_PROXYLIST_SIZE 256
+typedef struct sb_route_s {
+	char proxylist[SB_ROUTE_PROXYLIST_SIZE];
+	int total_cost_ms;
+	int hops;
+} sb_route_t;
+
+int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_routes);
 void SB_Proxylist_Unserialize_f(void);
 
 #define SB_TRIGGER_REFRESHDONE        1

--- a/src/EX_browser_pathfind.c
+++ b/src/EX_browser_pathfind.c
@@ -56,6 +56,12 @@ extern cvar_t sb_listcache;
 #define PROXY_REPLY_ENTRY_LEN 8
 #define PROXY_REPLY_BUFFER_SIZE (PROXY_REPLY_ENTRY_LEN*MAX_SERVERS)
 
+// qwfwd mesh-capable reply: OOB + 'Q''M' + type(1) + nonce(4), followed
+// by ip(4), port(2), average ping(2), jitter(2), loss percent(2).
+#define MESH_REPLY_HEADER_LEN 11
+#define MESH_REPLY_ENTRY_LEN 12
+#define MESH_MSG_PINGSTATUS_REPLY 1
+
 // current amount of qw servers ~ 300... but neighbour count means MAX_SERVERS*MAX_NONLEAVES
 #define INVALID_NODE (-1)
 typedef int nodeid_t;
@@ -90,6 +96,8 @@ typedef struct proxy_query_request_t {
 	socket_t sock;
 	nodeid_t nodeid;
 	qbool done;
+	qbool ping_received;
+	unsigned int mesh_nonce;
 } proxy_query_request_t;
 
 typedef struct proxy_request_queue_t {
@@ -292,6 +300,55 @@ static void SB_Proxy_ParseReply(const byte *buf, size_t buflen, proxy_ping_repor
 	}
 }
 
+static qbool SB_Mesh_ParseReply(const byte *buf, size_t buflen,
+	unsigned int expected_nonce, proxy_ping_report_callback callback)
+{
+	size_t offset;
+	unsigned int nonce;
+
+	if (buflen < MESH_REPLY_HEADER_LEN ||
+	    buf[0] != 0xff || buf[1] != 0xff || buf[2] != 0xff || buf[3] != 0xff ||
+	    buf[4] != 'Q' || buf[5] != 'M' ||
+	    buf[6] != MESH_MSG_PINGSTATUS_REPLY ||
+	    (buflen - MESH_REPLY_HEADER_LEN) % MESH_REPLY_ENTRY_LEN != 0)
+		return false;
+
+	nonce = (unsigned int)buf[7] |
+	        ((unsigned int)buf[8] << 8) |
+	        ((unsigned int)buf[9] << 16) |
+	        ((unsigned int)buf[10] << 24);
+	if (!nonce || nonce != expected_nonce)
+		return false;
+
+	for (offset = MESH_REPLY_HEADER_LEN;
+	     offset + MESH_REPLY_ENTRY_LEN <= buflen;
+	     offset += MESH_REPLY_ENTRY_LEN) {
+		netadr_t adr;
+		int ping, jitter, loss, quality_cost;
+
+		memset(&adr, 0, sizeof(adr));
+		adr.type = NA_IP;
+		memcpy(adr.ip, buf + offset, 4);
+		adr.port = htons((unsigned short)(buf[offset + 4] |
+		                              (buf[offset + 5] << 8)));
+		ping = (short)(buf[offset + 6] | (buf[offset + 7] << 8));
+		jitter = (short)(buf[offset + 8] | (buf[offset + 9] << 8));
+		loss = (short)(buf[offset + 10] | (buf[offset + 11] << 8));
+		if (ping < 0 || jitter < 0 || loss < 0 || loss > 100)
+			continue;
+
+		// Preserve the existing dist_t graph while making route selection
+		// quality-aware.  A small ping advantage no longer beats severe
+		// jitter/loss; UI bestping remains an estimated route cost.
+		quality_cost = ping + jitter / 2 + loss * 2;
+		if (quality_cost > SHRT_MAX)
+			quality_cost = SHRT_MAX;
+		callback(adr, (dist_t)quality_cost);
+	}
+
+	return true;
+}
+
 void SB_Proxy_QueryForPingList(const netadr_t *address, proxy_ping_report_callback callback)
 {
 	byte buf[PROXY_REPLY_BUFFER_SIZE];
@@ -398,6 +455,8 @@ int SB_PingTree_SendQueryThread(void *thread_arg)
 		if (!queue->data[i].done) {
 			struct sockaddr_storage addr_to;
 			netadr_t netadr;
+			char mesh_query[64];
+			int mesh_query_len;
 
 			// Validate nodeid
 			if (queue->data[i].nodeid < 0 || queue->data[i].nodeid >= ping_nodes_count) {
@@ -408,11 +467,23 @@ int SB_PingTree_SendQueryThread(void *thread_arg)
 			netadr = SB_NodeNetadr_Get(queue->data[i].nodeid);
 
 			NetadrToSockadr(&netadr, &addr_to);
-			ret = sendto(queue->data[i].sock,
-				PROXY_PINGLIST_QUERY, PROXY_PINGLIST_QUERY_LEN, 0,
+			// Always ask for the rich mesh snapshot first.  Updated qwfwd
+			// instances answer with avg/jitter/loss; legacy instances ignore it.
+			mesh_query_len = snprintf(mesh_query, sizeof(mesh_query),
+				"\xff\xff\xff\xffmeshprobe %u", queue->data[i].mesh_nonce);
+			ret = sendto(queue->data[i].sock, mesh_query, mesh_query_len, 0,
 				(struct sockaddr *) &addr_to, sizeof (struct sockaddr));
-			if (ret < 0) {
-				Com_DPrintf("SB_PingTree_SendQueryThread sendto returned %d\n", ret);
+			if (ret < 0)
+				Com_DPrintf("SB_PingTree_SendQueryThread mesh sendto returned %d\n", ret);
+
+			// Keep byte-for-byte legacy compatibility and provide an immediate
+			// fallback when the remote proxy has not been upgraded.
+			if (!queue->data[i].ping_received) {
+				ret = sendto(queue->data[i].sock,
+					PROXY_PINGLIST_QUERY, PROXY_PINGLIST_QUERY_LEN, 0,
+					(struct sockaddr *) &addr_to, sizeof (struct sockaddr));
+				if (ret < 0)
+					Com_DPrintf("SB_PingTree_SendQueryThread ping sendto returned %d\n", ret);
 			}
 			Sys_MSleep(interval_ms);
 		}
@@ -505,6 +576,7 @@ static qbool SB_PingTree_RecvQuery(proxy_request_queue *queue, FILE *f)
 			if (!queue->data[i].done && FD_ISSET(queue->data[i].sock, &recvset)) {
 				byte buf[PROXY_REPLY_BUFFER_SIZE];
 				struct sockaddr_storage addr_from;
+				netadr_t from, expected;
 				socklen_t addr_from_len = sizeof(struct sockaddr_in);
 
 				ret = recvfrom(queue->data[i].sock, (char *) buf, PROXY_REPLY_BUFFER_SIZE, 0, (struct sockaddr *) &addr_from, &addr_from_len);
@@ -513,14 +585,37 @@ static qbool SB_PingTree_RecvQuery(proxy_request_queue *queue, FILE *f)
 					continue;
 				}
 
-				if (strncmp("\xff\xff\xff\xffn", (char *) buf, 5) == 0) {
+				SockadrToNetadr(&addr_from, &from);
+				expected = SB_NodeNetadr_Get(queue->data[i].nodeid);
+				if (!NET_CompareAdr(from, expected)) {
+					Com_DPrintf("SB_PingTree_RecvQuery ignored unexpected source\n");
+					continue;
+				}
+
+				if (ret >= 5 && !queue->data[i].ping_received &&
+				    memcmp("\xff\xff\xff\xffn", buf, 5) == 0) {
 					nodeid_t id = queue->data[i].nodeid;
-					queue->data[i].done = true;
+					queue->data[i].ping_received = true;
 					ping_nodes[id].nlist_start = ping_neighbours_count;
 					if (f && ret > 5)
 							SB_Proxylist_Serialize_Reply(f, SB_NodeNetadr_Get(id), buf+5, ret-5);
 					SB_Proxy_ParseReply(buf+5, ret-5, SB_PingTree_AddProxyPing);
 					ping_nodes[id].nlist_end = ping_neighbours_count;
+				}
+				else if (ret >= MESH_REPLY_HEADER_LEN) {
+					nodeid_t id = queue->data[i].nodeid;
+					nodeid_t old_start = ping_nodes[id].nlist_start;
+					nodeid_t old_end = ping_nodes[id].nlist_end;
+					ping_nodes[id].nlist_start = ping_neighbours_count;
+					if (SB_Mesh_ParseReply(buf, (size_t)ret,
+					        queue->data[i].mesh_nonce, SB_PingTree_AddProxyPing)) {
+						ping_nodes[id].nlist_end = ping_neighbours_count;
+						queue->data[i].done = true;
+					}
+					else {
+						ping_nodes[id].nlist_start = old_start;
+						ping_nodes[id].nlist_end = old_end;
+					}
 				}
 				else {
 					Com_DPrintf("Invalid reply received\n");
@@ -573,7 +668,12 @@ static void SB_PingTree_ScanProxies(void)
 	for (i = 0; i < ping_nodes_count; i++) {
 		if (ping_nodes[i].proxport) {
 			queue->data[request].done = false;
+			queue->data[request].ping_received = false;
 			queue->data[request].nodeid = i;
+			queue->data[request].mesh_nonce =
+				((unsigned int)rand() << 16) ^ (unsigned int)rand() ^ (unsigned int)(request + 1);
+			if (!queue->data[request].mesh_nonce)
+				queue->data[request].mesh_nonce = (unsigned int)(request + 1);
 			queue->data[request].sock = UDP_OpenSocket(PORT_ANY);
 			request++;
 		}
@@ -765,6 +865,59 @@ int SB_PingTree_GetPathLen(const netadr_t *addr)
 
 		return proxies;
 	}
+}
+
+/// Returns the proxy chain string for the best path to addr.
+/// Does NOT modify cl_proxyaddr, does NOT issue any connect command.
+///
+/// out receives the proxylist string, e.g. "1.2.3.4:30000" or
+/// "1.2.3.4:30000@5.6.7.8:30000" for multi-hop routes.
+/// out_total_ping_ms receives the Dijkstra total ping estimate.
+///
+/// Returns true  if a proxy route was found and written to out.
+/// Returns false if direct connection is best, or no route exists.
+qbool SB_PingTree_GetProxyString(const netadr_t *addr, char *out, size_t outsz,
+                                  int *out_total_ping_ms)
+{
+	nodeid_t target = SB_PingTree_FindIp(SB_Netaddr2Ipaddr(addr));
+
+	out[0] = '\0';
+	*out_total_ping_ms = 0;
+
+	if (target == INVALID_NODE || ping_nodes[target].prev == INVALID_NODE) {
+		return false;
+	}
+
+	*out_total_ping_ms = (int)ping_nodes[target].dist;
+
+	if (ping_nodes[target].prev == startnode_id) {
+		return false;
+	}
+
+	{
+		char proxylist_buf[32 * MAX_NONLEAVES];
+		nodeid_t current = ping_nodes[target].prev;
+
+		proxylist_buf[0] = '\0';
+
+		while (current != startnode_id && current != INVALID_NODE) {
+			byte *ip = ping_nodes[current].ipaddr.data;
+			char newval[2048];
+
+			snprintf(&newval[0], sizeof(newval), "%d.%d.%d.%d:%d%s%s",
+			         (int)ip[0], (int)ip[1], (int)ip[2], (int)ip[3],
+			         (int)ntohs(ping_nodes[current].proxport),
+			         *proxylist_buf ? "@" : "",
+			         proxylist_buf);
+			strlcpy(proxylist_buf, newval, sizeof(proxylist_buf));
+
+			current = ping_nodes[current].prev;
+		}
+
+		strlcpy(out, proxylist_buf, outsz);
+	}
+
+	return (out[0] != '\0');
 }
 
 /// Connects to given QW server using the best available route

--- a/src/EX_browser_pathfind.c
+++ b/src/EX_browser_pathfind.c
@@ -920,6 +920,171 @@ qbool SB_PingTree_GetProxyString(const netadr_t *addr, char *out, size_t outsz,
 	return (out[0] != '\0');
 }
 
+/*
+ * Return the best route for every viable first hop.  This keeps route
+ * discovery in sb_findroutes: connectbr is only a user-facing selector and
+ * connectnext advances through this cached ranking without probing again.
+ *
+ * One reverse Dijkstra from the destination gives the cheapest continuation
+ * from every proxy.  Combining that with each measured local->proxy edge
+ * produces independent alternatives without maintaining a second graph.
+ */
+int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_routes)
+{
+	nodeid_t target;
+	int *heads, *rev_next, *rev_source, *dist, *next_hop;
+	qbool *visited;
+	int reverse_count = 0;
+	int i, source, count = 0;
+
+	if (!routes || max_routes <= 0 || !SB_PingTree_Built() || building_pingtree)
+		return 0;
+	if (max_routes > SB_ROUTE_MAX_ALTERNATIVES)
+		max_routes = SB_ROUTE_MAX_ALTERNATIVES;
+
+	target = SB_PingTree_FindIp(SB_Netaddr2Ipaddr(addr));
+	if (target == INVALID_NODE)
+		return 0;
+
+	heads = (int *)Q_malloc(sizeof(int) * ping_nodes_count);
+	rev_next = (int *)Q_malloc(sizeof(int) * ping_neighbours_count);
+	rev_source = (int *)Q_malloc(sizeof(int) * ping_neighbours_count);
+	dist = (int *)Q_malloc(sizeof(int) * ping_nodes_count);
+	next_hop = (int *)Q_malloc(sizeof(int) * ping_nodes_count);
+	visited = (qbool *)Q_malloc(sizeof(qbool) * ping_nodes_count);
+	if (!heads || !rev_next || !rev_source || !dist || !next_hop || !visited)
+		goto cleanup;
+
+	for (i = 0; i < ping_nodes_count; i++) {
+		heads[i] = -1;
+		dist[i] = INT_MAX;
+		next_hop[i] = INVALID_NODE;
+		visited[i] = false;
+	}
+
+	for (source = 0; source < ping_nodes_count; source++) {
+		if (ping_nodes[source].nlist_start == INVALID_NODE)
+			continue;
+		for (i = ping_nodes[source].nlist_start; i < ping_nodes[source].nlist_end; i++) {
+			nodeid_t destination = ping_neighbours[i].id;
+			rev_source[reverse_count] = source;
+			rev_next[reverse_count] = heads[destination];
+			heads[destination] = reverse_count++;
+		}
+	}
+
+	dist[target] = 0;
+	for (;;) {
+		nodeid_t current = INVALID_NODE;
+		int best = INT_MAX;
+		for (i = 0; i < ping_nodes_count; i++) {
+			if (!visited[i] && dist[i] < best) {
+				best = dist[i];
+				current = i;
+			}
+		}
+		if (current == INVALID_NODE)
+			break;
+		visited[current] = true;
+		for (i = heads[current]; i >= 0; i = rev_next[i]) {
+			nodeid_t predecessor = rev_source[i];
+			int edge_index;
+			if (predecessor == startnode_id)
+				continue;
+			for (edge_index = ping_nodes[predecessor].nlist_start;
+			     edge_index < ping_nodes[predecessor].nlist_end; edge_index++) {
+				if (ping_neighbours[edge_index].id == current) {
+					int alternative = dist[current] + ping_neighbours[edge_index].dist;
+					if (alternative < dist[predecessor]) {
+						dist[predecessor] = alternative;
+						next_hop[predecessor] = current;
+					}
+					break;
+				}
+			}
+		}
+	}
+
+	if (ping_nodes[startnode_id].nlist_start != INVALID_NODE) {
+		for (i = ping_nodes[startnode_id].nlist_start;
+		     i < ping_nodes[startnode_id].nlist_end; i++) {
+			nodeid_t first = ping_neighbours[i].id;
+			sb_route_t candidate;
+			nodeid_t current;
+			int duplicate = false;
+			int safety = 0;
+
+			memset(&candidate, 0, sizeof(candidate));
+			if (first == target) {
+				candidate.total_cost_ms = ping_neighbours[i].dist;
+			}
+			else {
+				if (!ping_nodes[first].proxport || dist[first] == INT_MAX)
+					continue;
+				candidate.total_cost_ms = ping_neighbours[i].dist + dist[first];
+				current = first;
+				while (current != target && current != INVALID_NODE && safety++ < MAX_NONLEAVES) {
+					byte *ip = ping_nodes[current].ipaddr.data;
+					char proxy[48];
+					if (!ping_nodes[current].proxport) {
+						candidate.proxylist[0] = '\0';
+						break;
+					}
+					snprintf(proxy, sizeof(proxy), "%d.%d.%d.%d:%d",
+					         ip[0], ip[1], ip[2], ip[3], ntohs(ping_nodes[current].proxport));
+					if (candidate.proxylist[0])
+						strlcat(candidate.proxylist, "@", sizeof(candidate.proxylist));
+					strlcat(candidate.proxylist, proxy, sizeof(candidate.proxylist));
+					candidate.hops++;
+					current = next_hop[current];
+				}
+				if (current != target || !candidate.proxylist[0])
+					continue;
+			}
+
+			for (source = 0; source < count; source++) {
+				if (!strcmp(routes[source].proxylist, candidate.proxylist)) {
+					duplicate = true;
+					break;
+				}
+			}
+			if (!duplicate) {
+				if (count < max_routes) {
+					routes[count++] = candidate;
+				}
+				else {
+					int worst = 0;
+					for (source = 1; source < count; source++)
+						if (routes[source].total_cost_ms > routes[worst].total_cost_ms)
+							worst = source;
+					if (candidate.total_cost_ms < routes[worst].total_cost_ms)
+						routes[worst] = candidate;
+				}
+			}
+		}
+	}
+
+	/* The candidate count is small; insertion sort keeps this C89-friendly. */
+	for (i = 1; i < count; i++) {
+		sb_route_t value = routes[i];
+		int pos = i;
+		while (pos > 0 && routes[pos - 1].total_cost_ms > value.total_cost_ms) {
+			routes[pos] = routes[pos - 1];
+			pos--;
+		}
+		routes[pos] = value;
+	}
+
+cleanup:
+	Q_free(heads);
+	Q_free(rev_next);
+	Q_free(rev_source);
+	Q_free(dist);
+	Q_free(next_hop);
+	Q_free(visited);
+	return count;
+}
+
 /// Connects to given QW server using the best available route
 void SB_PingTree_ConnectBestPath(const netadr_t *addr)
 {

--- a/src/EX_browser_pathfind.c
+++ b/src/EX_browser_pathfind.c
@@ -118,6 +118,7 @@ static nodeid_t startnode_id = 0;
 
 static qbool building_pingtree = false; // when true, the pingtree build thread is still working
 static qbool pingtree_built = false;
+static double pingtree_built_at;
 
 static sem_t phase2thread_lock;
 
@@ -791,13 +792,19 @@ int SB_PingTree_Phase2(void *ignored_arg)
 	Sys_SemPost(&phase2thread_lock);
 	building_pingtree = false;
 	pingtree_built = true;
+	pingtree_built_at = Sys_DoubleTime();
 	return 0;
 }
 
 /// Has the Ping Tree been already built?
 qbool SB_PingTree_Built(void)
 {
-	return ping_nodes_count > 0;
+	return pingtree_built;
+}
+
+double SB_PingTree_Age(void)
+{
+	return pingtree_built_at > 0 ? Sys_DoubleTime() - pingtree_built_at : DBL_MAX;
 }
 
 /// Creates whole graph structure for looking up shortest paths to servers (ping-wise).
@@ -811,6 +818,8 @@ void SB_PingTree_Build(void)
 	}
 	// no race condition here, as this must always get executed by the main thread
 	building_pingtree = true;
+	pingtree_built = false;
+	pingtree_built_at = 0;
 	Com_Printf("Building the Ping Tree...\n");
 
 	// first quick phase is initialization + quick read of data from the server browser
@@ -819,6 +828,9 @@ void SB_PingTree_Build(void)
 	Sys_SemWait(&phase2thread_lock);
 	if (Sys_CreateDetachedThread(SB_PingTree_Phase2, NULL) < 0) {
 		Com_Printf("Failed to create SB_PingTree_Phase2 thread\n");
+		building_pingtree = false;
+		pingtree_built = false;
+		Sys_SemPost(&phase2thread_lock);
 	}
 }
 
@@ -932,7 +944,7 @@ qbool SB_PingTree_GetProxyString(const netadr_t *addr, char *out, size_t outsz,
 int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_routes)
 {
 	nodeid_t target;
-	int *heads, *rev_next, *rev_source, *dist, *next_hop;
+	int *heads, *rev_next, *rev_source, *dist, *next_hop, *route_hops;
 	qbool *visited;
 	int reverse_count = 0;
 	int i, source, count = 0;
@@ -951,14 +963,16 @@ int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_rout
 	rev_source = (int *)Q_malloc(sizeof(int) * ping_neighbours_count);
 	dist = (int *)Q_malloc(sizeof(int) * ping_nodes_count);
 	next_hop = (int *)Q_malloc(sizeof(int) * ping_nodes_count);
+	route_hops = (int *)Q_malloc(sizeof(int) * ping_nodes_count);
 	visited = (qbool *)Q_malloc(sizeof(qbool) * ping_nodes_count);
-	if (!heads || !rev_next || !rev_source || !dist || !next_hop || !visited)
+	if (!heads || !rev_next || !rev_source || !dist || !next_hop || !route_hops || !visited)
 		goto cleanup;
 
 	for (i = 0; i < ping_nodes_count; i++) {
 		heads[i] = -1;
 		dist[i] = INT_MAX;
 		next_hop[i] = INVALID_NODE;
+		route_hops[i] = INT_MAX;
 		visited[i] = false;
 	}
 
@@ -974,6 +988,7 @@ int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_rout
 	}
 
 	dist[target] = 0;
+	route_hops[target] = 0;
 	for (;;) {
 		nodeid_t current = INVALID_NODE;
 		int best = INT_MAX;
@@ -989,15 +1004,20 @@ int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_rout
 		for (i = heads[current]; i >= 0; i = rev_next[i]) {
 			nodeid_t predecessor = rev_source[i];
 			int edge_index;
-			if (predecessor == startnode_id)
+			if (predecessor == startnode_id || route_hops[current] >= MAX_NONLEAVES)
 				continue;
 			for (edge_index = ping_nodes[predecessor].nlist_start;
 			     edge_index < ping_nodes[predecessor].nlist_end; edge_index++) {
 				if (ping_neighbours[edge_index].id == current) {
-					int alternative = dist[current] + ping_neighbours[edge_index].dist;
+					int alternative;
+					if (ping_neighbours[edge_index].dist < 0 ||
+					    dist[current] > INT_MAX - ping_neighbours[edge_index].dist)
+						break;
+					alternative = dist[current] + ping_neighbours[edge_index].dist;
 					if (alternative < dist[predecessor]) {
 						dist[predecessor] = alternative;
 						next_hop[predecessor] = current;
+						route_hops[predecessor] = route_hops[current] + 1;
 					}
 					break;
 				}
@@ -1021,6 +1041,9 @@ int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_rout
 			else {
 				if (!ping_nodes[first].proxport || dist[first] == INT_MAX)
 					continue;
+				if (ping_neighbours[i].dist < 0 ||
+				    dist[first] > INT_MAX - ping_neighbours[i].dist)
+					continue;
 				candidate.total_cost_ms = ping_neighbours[i].dist + dist[first];
 				current = first;
 				while (current != target && current != INVALID_NODE && safety++ < MAX_NONLEAVES) {
@@ -1032,6 +1055,11 @@ int SB_PingTree_GetRoutes(const netadr_t *addr, sb_route_t *routes, int max_rout
 					}
 					snprintf(proxy, sizeof(proxy), "%d.%d.%d.%d:%d",
 					         ip[0], ip[1], ip[2], ip[3], ntohs(ping_nodes[current].proxport));
+					if (strlen(candidate.proxylist) + (candidate.proxylist[0] ? 1 : 0) +
+					    strlen(proxy) + 1 > sizeof(candidate.proxylist)) {
+						candidate.proxylist[0] = '\0';
+						break;
+					}
 					if (candidate.proxylist[0])
 						strlcat(candidate.proxylist, "@", sizeof(candidate.proxylist));
 					strlcat(candidate.proxylist, proxy, sizeof(candidate.proxylist));
@@ -1081,6 +1109,7 @@ cleanup:
 	Q_free(rev_source);
 	Q_free(dist);
 	Q_free(next_hop);
+	Q_free(route_hops);
 	Q_free(visited);
 	return count;
 }
@@ -1190,6 +1219,7 @@ void SB_Proxylist_Unserialize_f(void)
 		SB_PingTree_Dijkstra();
 		SB_PingTree_UpdateServerList();
 		pingtree_built = true;
+		pingtree_built_at = Sys_DoubleTime();
 	}
 	else if (err == -1) {
 		Com_Printf("Format didn't match\n");

--- a/src/EX_qtvlist.c
+++ b/src/EX_qtvlist.c
@@ -392,7 +392,10 @@ static void qtvlist_get_gameaddress(const char *qtvaddress, char *out_addr, size
 
 				port = json_integer_value(json_object_get(gs_entry, "Port"));
 
-				snprintf(out_addr, out_addr_len, "%s:%" JSON_INTEGER_FORMAT, ipaddress, port);
+				// port is a network port (fits in 16 bits); format as plain
+				// int instead of via JSON_INTEGER_FORMAT, whose "%I64d" on
+				// mingw doesn't satisfy gcc's -Werror=format for json_int_t.
+				snprintf(out_addr, out_addr_len, "%s:%d", ipaddress, (int) port);
 				return;
 			}
 		}

--- a/src/cl_connectbr.c
+++ b/src/cl_connectbr.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2024 unezQuake team
+Copyright (C) 2024-2026 ezQuake contributors
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -20,11 +20,11 @@ probing the worldwide proxy list a second time.
 
 extern cvar_t cl_proxyaddr;
 
-cvar_t cl_connectbr_verbose = {"cl_connectbr_verbose", "1", CVAR_ARCHIVE};
 cvar_t cl_connectbr_debug   = {"cl_connectbr_debug",   "0", CVAR_ARCHIVE};
 
 #define CONNECTBR_DISPLAY_ROUTES 5
 #define MAX_ADDRESS_LENGTH 128
+#define CONNECTBR_ROUTE_TTL 120.0
 
 static sb_route_t br_routes[SB_ROUTE_MAX_ALTERNATIVES];
 static int br_route_count;
@@ -32,6 +32,7 @@ static int br_current_route;
 static netadr_t br_target_addr;
 static qbool br_active;
 static qbool br_pending;
+static double br_routes_built_at;
 
 static const char *CL_BR_RouteColor(int cost_ms, int best_cost_ms)
 {
@@ -83,6 +84,7 @@ static void CL_BR_BuildRankingAndConnect(void)
 	                                       SB_ROUTE_MAX_ALTERNATIVES);
 	br_current_route = 0;
 	br_active = br_route_count > 0;
+	br_routes_built_at = br_active ? Sys_DoubleTime() : 0;
 
 	if (!br_route_count) {
 		Com_Printf("connectbr: sb_findroutes found no route to %s.\n",
@@ -152,6 +154,12 @@ void CL_Connect_BestRoute_f(void)
 		SB_PingTree_Build();
 		return;
 	}
+	if (SB_PingTree_Age() > CONNECTBR_ROUTE_TTL) {
+		br_pending = true;
+		Com_Printf("connectbr: cached measurements expired; refreshing sb_findroutes...\n");
+		SB_PingTree_Build();
+		return;
+	}
 
 	CL_BR_BuildRankingAndConnect();
 }
@@ -161,6 +169,14 @@ void CL_Connect_Next_f(void)
 	if (!br_active || !br_route_count) {
 		Com_Printf("connectnext: no cached connectbr ranking.\n");
 		Com_Printf("  Use 'connectbr <address>' first.\n");
+		return;
+	}
+	if (Sys_DoubleTime() - br_routes_built_at > CONNECTBR_ROUTE_TTL) {
+		Com_Printf("connectnext: cached routes expired; refreshing sb_findroutes...\n");
+		br_active = false;
+		br_route_count = 0;
+		br_pending = true;
+		SB_PingTree_Build();
 		return;
 	}
 
@@ -179,12 +195,15 @@ void CL_ConnectBR_Frame(void)
 {
 	if (br_pending && !SB_PingTree_IsBuilding() && SB_PingTree_Built())
 		CL_BR_BuildRankingAndConnect();
+	else if (br_pending && !SB_PingTree_IsBuilding() && !SB_PingTree_Built()) {
+		br_pending = false;
+		Com_Printf("connectbr: sb_findroutes could not build the route graph.\n");
+	}
 }
 
 void CL_ConnectBR_Init(void)
 {
 	Cvar_SetCurrentGroup(CVAR_GROUP_NETWORK);
-	Cvar_Register(&cl_connectbr_verbose);
 	Cvar_Register(&cl_connectbr_debug);
 	Cvar_ResetCurrentGroup();
 }

--- a/src/cl_connectbr.c
+++ b/src/cl_connectbr.c
@@ -10,8 +10,9 @@ cl_connectbr.c - User-facing route selection commands.
 
 Route discovery, measurements and graph calculation belong exclusively to
 sb_findroutes (EX_browser_pathfind.c). connectbr selects the best cached
-route and connectnext advances through the cached alternatives without
-probing the worldwide proxy list a second time.
+route; connectnext/connectprevious step through the cached alternatives
+without probing the worldwide proxy list a second time; connectinfo lists
+them without connecting.
 */
 
 #include "quakedef.h"
@@ -70,6 +71,8 @@ static void CL_BR_ApplyRoute(int index)
 		Com_Printf("  type &cf80connectnext&r to try route #%d\n", index + 2);
 	else
 		Com_Printf("  no more routes available.\n");
+	if (index > 0)
+		Com_Printf("  type &cf80connectprevious&r to go back to route #%d\n", index);
 
 	Cbuf_AddText(va("connect %s\n", NET_AdrToString(br_target_addr)));
 }
@@ -118,7 +121,8 @@ void CL_Connect_BestRoute_f(void)
 	if (Cmd_Argc() != 2) {
 		Com_Printf("Usage: connectbr <address>\n");
 		Com_Printf("  Uses the routes already measured by sb_findroutes.\n");
-		Com_Printf("  Use connectnext to try the next cached route.\n");
+		Com_Printf("  Use connectnext/connectprevious to try another cached route.\n");
+		Com_Printf("  Use connectinfo to list them without connecting.\n");
 		return;
 	}
 
@@ -182,13 +186,68 @@ void CL_Connect_Next_f(void)
 
 	if (br_current_route + 1 >= br_route_count) {
 		Com_Printf("connectnext: no more routes (tried all %d).\n", br_route_count);
-		br_active = false;
 		return;
 	}
 
 	br_current_route++;
 	Host_EndGame();
 	CL_BR_ApplyRoute(br_current_route);
+}
+
+void CL_Connect_Previous_f(void)
+{
+	if (!br_active || !br_route_count) {
+		Com_Printf("connectprevious: no cached connectbr ranking.\n");
+		Com_Printf("  Use 'connectbr <address>' first.\n");
+		return;
+	}
+	if (Sys_DoubleTime() - br_routes_built_at > CONNECTBR_ROUTE_TTL) {
+		Com_Printf("connectprevious: cached routes expired; refreshing sb_findroutes...\n");
+		br_active = false;
+		br_route_count = 0;
+		br_pending = true;
+		SB_PingTree_Build();
+		return;
+	}
+
+	if (br_current_route <= 0) {
+		Com_Printf("connectprevious: already at route #1, no earlier route.\n");
+		return;
+	}
+
+	br_current_route--;
+	Host_EndGame();
+	CL_BR_ApplyRoute(br_current_route);
+}
+
+void CL_Connect_Info_f(void)
+{
+	int i;
+	int show;
+
+	if (!br_active || !br_route_count) {
+		Com_Printf("connectinfo: no cached connectbr ranking.\n");
+		Com_Printf("  Use 'connectbr <address>' first.\n");
+		return;
+	}
+	if (Sys_DoubleTime() - br_routes_built_at > CONNECTBR_ROUTE_TTL) {
+		Com_Printf("connectinfo: cached routes expired; run connectbr again to refresh.\n");
+		return;
+	}
+
+	show = min(br_route_count, CONNECTBR_DISPLAY_ROUTES);
+	Com_Printf("\n&cf80connectinfo: top %d routes to %s&r\n", show, NET_AdrToString(br_target_addr));
+	for (i = 0; i < show; i++) {
+		const char *marker = (i == br_current_route) ? " &cff0<- current&r" : "";
+
+		if (br_routes[i].proxylist[0])
+			Com_Printf("  %s#%d&r  %dms  %d hop%s  %s%s\n", CL_BR_RouteColor(br_routes[i].total_cost_ms, br_routes[0].total_cost_ms), i + 1,
+			           br_routes[i].total_cost_ms, br_routes[i].hops,
+			           br_routes[i].hops == 1 ? "" : "s", br_routes[i].proxylist, marker);
+		else
+			Com_Printf("  %s#%d&r  %dms  direct%s\n", CL_BR_RouteColor(br_routes[i].total_cost_ms, br_routes[0].total_cost_ms), i + 1,
+			           br_routes[i].total_cost_ms, marker);
+	}
 }
 
 void CL_ConnectBR_Frame(void)

--- a/src/cl_connectbr.c
+++ b/src/cl_connectbr.c
@@ -33,13 +33,13 @@ static netadr_t br_target_addr;
 static qbool br_active;
 static qbool br_pending;
 
-static const char *CL_BR_RouteColor(int cost_ms)
+static const char *CL_BR_RouteColor(int cost_ms, int best_cost_ms)
 {
-	if (cost_ms <= 80)
+	if (best_cost_ms <= 0 || cost_ms <= best_cost_ms)
 		return "&c0f0";
-	if (cost_ms <= 140)
+	if ((long long)cost_ms * 100 <= (long long)best_cost_ms * 115)
 		return "&caf0";
-	if (cost_ms <= 220)
+	if ((long long)cost_ms * 100 <= (long long)best_cost_ms * 135)
 		return "&cff0";
 	return "&cf00";
 }
@@ -94,11 +94,11 @@ static void CL_BR_BuildRankingAndConnect(void)
 	Com_Printf("\n&cf80connectbr: top %d routes from sb_findroutes&r\n", show);
 	for (i = 0; i < show; i++) {
 		if (br_routes[i].proxylist[0])
-			Com_Printf("  %s#%d&r  %dms  %d hop%s  %s\n", CL_BR_RouteColor(br_routes[i].total_cost_ms), i + 1,
+			Com_Printf("  %s#%d&r  %dms  %d hop%s  %s\n", CL_BR_RouteColor(br_routes[i].total_cost_ms, br_routes[0].total_cost_ms), i + 1,
 			           br_routes[i].total_cost_ms, br_routes[i].hops,
 			           br_routes[i].hops == 1 ? "" : "s", br_routes[i].proxylist);
 		else
-			Com_Printf("  %s#%d&r  %dms  direct\n", CL_BR_RouteColor(br_routes[i].total_cost_ms), i + 1,
+			Com_Printf("  %s#%d&r  %dms  direct\n", CL_BR_RouteColor(br_routes[i].total_cost_ms, br_routes[0].total_cost_ms), i + 1,
 			           br_routes[i].total_cost_ms);
 	}
 

--- a/src/cl_connectbr.c
+++ b/src/cl_connectbr.c
@@ -23,7 +23,7 @@ extern cvar_t cl_proxyaddr;
 cvar_t cl_connectbr_verbose = {"cl_connectbr_verbose", "1", CVAR_ARCHIVE};
 cvar_t cl_connectbr_debug   = {"cl_connectbr_debug",   "0", CVAR_ARCHIVE};
 
-#define CONNECTBR_DISPLAY_ROUTES 6
+#define CONNECTBR_DISPLAY_ROUTES 5
 #define MAX_ADDRESS_LENGTH 128
 
 static sb_route_t br_routes[SB_ROUTE_MAX_ALTERNATIVES];
@@ -32,6 +32,17 @@ static int br_current_route;
 static netadr_t br_target_addr;
 static qbool br_active;
 static qbool br_pending;
+
+static const char *CL_BR_RouteColor(int cost_ms)
+{
+	if (cost_ms <= 80)
+		return "&c80ff80";
+	if (cost_ms <= 140)
+		return "&cffef80";
+	if (cost_ms <= 220)
+		return "&cffff80";
+	return "&cff8080";
+}
 
 static void CL_BR_ApplyRoute(int index)
 {
@@ -83,11 +94,11 @@ static void CL_BR_BuildRankingAndConnect(void)
 	Com_Printf("\n&cf80connectbr: top %d routes from sb_findroutes&r\n", show);
 	for (i = 0; i < show; i++) {
 		if (br_routes[i].proxylist[0])
-			Com_Printf("  &cf80#%d&r  %dms  %d hop%s  %s\n", i + 1,
+			Com_Printf("  %s#%d&r  %dms  %d hop%s  %s\n", CL_BR_RouteColor(br_routes[i].total_cost_ms), i + 1,
 			           br_routes[i].total_cost_ms, br_routes[i].hops,
 			           br_routes[i].hops == 1 ? "" : "s", br_routes[i].proxylist);
 		else
-			Com_Printf("  &cf80#%d&r  %dms  direct\n", i + 1,
+			Com_Printf("  %s#%d&r  %dms  direct\n", CL_BR_RouteColor(br_routes[i].total_cost_ms), i + 1,
 			           br_routes[i].total_cost_ms);
 	}
 

--- a/src/cl_connectbr.c
+++ b/src/cl_connectbr.c
@@ -1,771 +1,178 @@
 /*
 Copyright (C) 2024 unezQuake team
 
-cl_connectbr.c - Smart route selection for connectbr/connectnext commands
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 
-Multi-hop logic:
-  Batch-queries all proxy candidates simultaneously (one socket each).
-  Collects all pingstatus replies in a single select() loop -- total wait
-  is ONE timeout window regardless of how many proxies are tested.
+cl_connectbr.c - User-facing route selection commands.
 
-  1-hop:  you -> P1 -> dest
-  2-hop:  you -> P1 -> P2 -> dest
-          P2 candidates are proxies (port 30000) found in P1's pingstatus.
-          A second batch round queries all P2 candidates.
-
-CVars:
-  cl_connectbr_timeout_ms     - pingstatus reply timeout in ms (default 600)
-  cl_connectbr_ping_green     - green ping threshold (default 40)
-  cl_connectbr_ping_yellow    - yellow ping threshold (default 80)
-  cl_connectbr_ping_orange    - orange/max playable threshold (default 200)
-  cl_connectbr_weight_ping    - score weight for ping (default 1.0)
-  cl_connectbr_weight_loss    - score weight for loss (default 0.4)
-  cl_connectbr_test_packets   - number of pingstatus packets to send for loss (default 10)
-  cl_connectbr_packet_delay   - delay between packets in ms (default 15)
-  cl_connectbr_verbose        - 0=quiet 1=normal 2=debug (default 1)
+Route discovery, measurements and graph calculation belong exclusively to
+sb_findroutes (EX_browser_pathfind.c). connectbr selects the best cached
+route and connectnext advances through the cached alternatives without
+probing the worldwide proxy list a second time.
 */
 
 #include "quakedef.h"
 #include "EX_browser.h"
 #include "cl_connectbr.h"
 
-// cl_proxyaddr is declared in cl_main.c
 extern cvar_t cl_proxyaddr;
 
-// --------------------------------------------
-// CVars
-// --------------------------------------------
-cvar_t cl_connectbr_timeout_ms    = {"cl_connectbr_timeout_ms",    "600",  CVAR_ARCHIVE};
-cvar_t cl_connectbr_ping_green    = {"cl_connectbr_ping_green",    "40",   CVAR_ARCHIVE};
-cvar_t cl_connectbr_ping_yellow   = {"cl_connectbr_ping_yellow",   "80",   CVAR_ARCHIVE};
-cvar_t cl_connectbr_ping_orange   = {"cl_connectbr_ping_orange",   "200",  CVAR_ARCHIVE};
-cvar_t cl_connectbr_weight_ping   = {"cl_connectbr_weight_ping",   "1.0",  CVAR_ARCHIVE};
-cvar_t cl_connectbr_weight_loss   = {"cl_connectbr_weight_loss",   "0.4",  CVAR_ARCHIVE};
-cvar_t cl_connectbr_test_packets  = {"cl_connectbr_test_packets",  "10",   CVAR_ARCHIVE};
-cvar_t cl_connectbr_packet_delay  = {"cl_connectbr_packet_delay",  "15",   CVAR_ARCHIVE};
-cvar_t cl_connectbr_verbose       = {"cl_connectbr_verbose",       "1",    CVAR_ARCHIVE};
-cvar_t cl_connectbr_debug         = {"cl_connectbr_debug",         "0",    CVAR_ARCHIVE};
+cvar_t cl_connectbr_verbose = {"cl_connectbr_verbose", "1", CVAR_ARCHIVE};
+cvar_t cl_connectbr_debug   = {"cl_connectbr_debug",   "0", CVAR_ARCHIVE};
 
-// --------------------------------------------
-// Constants
-// --------------------------------------------
-#define CONNECTBR_MAX_PROXIES     128  /* 91 proxies qwfwd ativos globalmente (Mar/2026) */
-#define CONNECTBR_MAX_NEIGHBORS   64
-/* max rotas = 64 proxies (1-hop) + combinacoes 2-hop + 1 direta.
- * 256 cobre o pior caso pratico com folga (route_t ~600 bytes, total ~150KB). */
-#define CONNECTBR_MAX_ROUTES      256
-#define MAX_PROXYLIST             256
-#define MAX_ADDRESS_LENGTH        128
+#define CONNECTBR_DISPLAY_ROUTES 6
+#define MAX_ADDRESS_LENGTH 128
 
-#define BR_Debug(...) \
-	do { if (cl_connectbr_debug.value) Com_Printf("[connectbr] " __VA_ARGS__); } while(0)
+static sb_route_t br_routes[SB_ROUTE_MAX_ALTERNATIVES];
+static int br_route_count;
+static int br_current_route;
+static netadr_t br_target_addr;
+static qbool br_active;
+static qbool br_pending;
 
-// --------------------------------------------
-// Types
-// --------------------------------------------
-typedef struct {
-	char    proxylist[MAX_PROXYLIST];
-	char    label[128];
-	float   ping_ms;
-	float   loss_pct;
-	float   score;
-	qbool   via_proxy;
-	qbool   valid;
-} route_t;
-
-typedef struct {
-	netadr_t addr;
-	int      dist_ms;
-} ps_entry_t;
-
-typedef struct {
-	ps_entry_t entries[CONNECTBR_MAX_NEIGHBORS];
-	int        count;
-	int        dest_ping;   /* proxy's ping to dest, -1 if not in reply */
-} ps_reply_t;
-
-typedef struct {
-	netadr_t  addr;
-	char      ip_str[64];
-	char      name[128];
-	int       you_ms;       /* you -> this proxy (from browser or measured) */
-	float     loss_pct;     /* packet loss to destination (for pingstatus) */
-	socket_t  sock;
-	qbool     replied;      /* received at least one pingstatus reply? */
-	ps_reply_t ps;
-} proxy_t;
-
-// --------------------------------------------
-// State
-// --------------------------------------------
-static route_t   br_routes[CONNECTBR_MAX_ROUTES];
-static int       br_route_count   = 0;
-static int       br_current_route = 0;
-static netadr_t  br_target_addr;
-static qbool     br_active        = false;
-static qbool     br_measuring     = false;
-static qbool     br_done          = false;
-static char      br_ranking_buf[4096];
-
-// --------------------------------------------
-// Colour helpers
-// --------------------------------------------
-static const char *CL_BR_PingColor(float ms)
+static void CL_BR_ApplyRoute(int index)
 {
-	int g = (int)cl_connectbr_ping_green.value;
-	int y = (int)cl_connectbr_ping_yellow.value;
-	int o = (int)cl_connectbr_ping_orange.value;
-	if (g <= 0) g = 40;
-	if (y <= 0) y = 80;
-	if (o <= 0) o = 200;
-	if (ms <= g) return "&c0f0";
-	if (ms <= y) return "&cff0";
-	if (ms <= o) return "&cfa0";
-	return "&cf00";
-}
+	sb_route_t *route;
 
-static const char *CL_BR_LossColor(float pct)
-{
-	if (pct <= 0) return "&c0f0";
-	if (pct <= 5) return "&cff0";
-	return "&cf00";
-}
-
-// --------------------------------------------
-// Helpers
-// --------------------------------------------
-static void CL_BR_AdrToStr(const netadr_t *a, char *buf, size_t bufsz)
-{
-	snprintf(buf, bufsz, "%d.%d.%d.%d:%d",
-	         a->ip[0], a->ip[1], a->ip[2], a->ip[3], (int)ntohs(a->port));
-}
-
-static qbool CL_BR_IsTarget(const netadr_t *a)
-{
-	return (memcmp(a->ip, br_target_addr.ip, 4) == 0 &&
-	        a->port == br_target_addr.port);
-}
-
-static qbool CL_BR_AdrEqual(const netadr_t *a, const netadr_t *b)
-{
-	return (memcmp(a->ip, b->ip, 4) == 0 && a->port == b->port);
-}
-
-static int CL_BR_GetBrowserPing(const netadr_t *dest)
-{
-	int i, best = -1;
-	SB_ServerList_Lock();
-	for (i = 0; i < serversn; i++) {
-		if (NET_CompareAdr(servers[i]->address, *dest) && servers[i]->ping >= 0) {
-			best = servers[i]->ping;
-			break;
-		}
-	}
-	SB_ServerList_Unlock();
-	return best;
-}
-
-// --------------------------------------------
-// Parse a raw pingstatus reply buffer.
-// --------------------------------------------
-static void CL_BR_ParsePingstatus(const byte *buf, int len,
-                                   const netadr_t *dest, ps_reply_t *ps)
-{
-	const byte *p   = buf;
-	const byte *end = buf + len;
-
-	ps->count     = 0;
-	ps->dest_ping = -1;
-
-	while (p + 8 <= end) {
-		unsigned short port_net;
-		short dist_raw;
-		int   dist_ms;
-
-		memcpy(&port_net, p + 4, 2);
-		memcpy(&dist_raw, p + 6, 2);
-		dist_ms = (int)(short)LittleShort(dist_raw);
-
-		if (dist_ms >= 0) {
-			if (dest &&
-			    memcmp(p, dest->ip, 4) == 0 &&
-			    memcmp(p + 4, &dest->port, 2) == 0) {
-				ps->dest_ping = dist_ms;
-			}
-			if (ps->count < CONNECTBR_MAX_NEIGHBORS) {
-				ps_entry_t *e = &ps->entries[ps->count++];
-				e->addr.type = NA_IP;
-				memcpy(e->addr.ip, p, 4);
-				e->addr.port = port_net;
-				e->dist_ms   = dist_ms;
-			}
-		}
-		p += 8;
-	}
-}
-
-// --------------------------------------------
-// Batch pingstatus -- sends to all proxies simultaneously,
-// measures you->proxy RTT from the first reply timing,
-// counts multiple replies to compute loss.
-// Total blocking time = timeout_ms, regardless of proxy count.
-// --------------------------------------------
-static void CL_BR_BatchPingstatus(proxy_t *proxies, int count,
-                                   const netadr_t *dest, int timeout_ms)
-{
-	const char *packet      = "\xff\xff\xff\xffpingstatus";
-	int         packet_count = (int)cl_connectbr_test_packets.value;
-	double     *send_times;
-	int        *recv_count;
-	int         i, pkt;
-	double      deadline;
-	struct timeval tv;
-
-	if (packet_count < 1)  packet_count = 1;
-	if (packet_count > 20) packet_count = 20;
-	if (timeout_ms <= 0)   timeout_ms   = 600;
-
-	send_times = (double *)Q_malloc(count * sizeof(double));
-	recv_count = (int    *)Q_malloc(count * sizeof(int));
-	if (!send_times || !recv_count) {
-		Q_free(send_times);
-		Q_free(recv_count);
+	if (index < 0 || index >= br_route_count)
 		return;
+
+	route = &br_routes[index];
+	Cvar_Set(&cl_proxyaddr, route->proxylist);
+
+	if (route->proxylist[0]) {
+		Com_Printf("\n&cf80connectbr:&r route #%d - %d hop%s, estimated cost %dms\n",
+		           index + 1, route->hops, route->hops == 1 ? "" : "s",
+		           route->total_cost_ms);
+		Com_Printf("  cl_proxyaddr %s\n", route->proxylist);
 	}
-	memset(recv_count, 0, count * sizeof(int));
-
-	/* open one socket per proxy, record send time, send all packets */
-	for (i = 0; i < count; i++) {
-		struct sockaddr_storage addr_to;
-		proxies[i].replied      = false;
-		proxies[i].loss_pct     = 100.0f;
-		proxies[i].ps.count     = 0;
-		proxies[i].ps.dest_ping = -1;
-		send_times[i]           = 0;
-
-		proxies[i].sock = UDP_OpenSocket(PORT_ANY);
-		if (proxies[i].sock == INVALID_SOCKET) continue;
-
-		NetadrToSockadr(&proxies[i].addr, &addr_to);
-		send_times[i] = Sys_DoubleTime();
-		for (pkt = 0; pkt < packet_count; pkt++) {
-			sendto(proxies[i].sock, packet, strlen(packet), 0,
-			       (struct sockaddr *)&addr_to, sizeof(struct sockaddr));
-		}
+	else {
+		Com_Printf("\n&cf80connectbr:&r route #%d - direct, estimated cost %dms\n",
+		           index + 1, route->total_cost_ms);
 	}
 
-	deadline = Sys_DoubleTime() + timeout_ms / 1000.0;
-
-	while (Sys_DoubleTime() < deadline) {
-		fd_set fd;
-		int    maxsock = 0;
-		qbool  any     = false;
-
-		FD_ZERO(&fd);
-		for (i = 0; i < count; i++) {
-			/* keep listening until we've received all expected replies or timed out */
-			if (recv_count[i] < packet_count && proxies[i].sock != INVALID_SOCKET) {
-				FD_SET(proxies[i].sock, &fd);
-				if ((int)proxies[i].sock > maxsock)
-					maxsock = (int)proxies[i].sock;
-				any = true;
-			}
-		}
-		if (!any) break;
-
-		tv.tv_sec = 0; tv.tv_usec = 20000;
-		if (select(maxsock + 1, &fd, NULL, NULL, &tv) <= 0) continue;
-
-		for (i = 0; i < count; i++) {
-			if (recv_count[i] < packet_count
-			    && proxies[i].sock != INVALID_SOCKET
-			    && FD_ISSET(proxies[i].sock, &fd)) {
-				byte buf[8 * 512];
-				struct sockaddr_storage from;
-				socklen_t from_len = sizeof(from);
-				double    now      = Sys_DoubleTime();
-				int ret = recvfrom(proxies[i].sock, (char *)buf, sizeof(buf), 0,
-				                   (struct sockaddr *)&from, &from_len);
-				if (ret > 5 && memcmp(buf, "\xff\xff\xff\xffn", 5) == 0) {
-					recv_count[i]++;
-					if (!proxies[i].replied) {
-						/* first reply: parse pingstatus data */
-						CL_BR_ParsePingstatus(buf + 5, ret - 5, dest, &proxies[i].ps);
-						proxies[i].replied = true;
-						/* measure you->proxy RTT from pingstatus round-trip
-						   (use this only if browser didn't already have a ping) */
-						if (proxies[i].you_ms < 0 && send_times[i] > 0) {
-							int ms = (int)((now - send_times[i]) * 1000.0);
-							proxies[i].you_ms = (ms < 1) ? 1 : ms;
-						}
-					}
-				}
-			}
-		}
-	}
-
-	/* compute packet loss for each proxy */
-	for (i = 0; i < count; i++) {
-		if (proxies[i].replied && recv_count[i] > 0) {
-			float loss = 100.0f * (1.0f - (float)recv_count[i] / (float)packet_count);
-			proxies[i].loss_pct = (loss < 0) ? 0 : loss;
-		}
-	}
-
-	Q_free(send_times);
-	Q_free(recv_count);
-
-	for (i = 0; i < count; i++) {
-		if (proxies[i].sock != INVALID_SOCKET) {
-			closesocket(proxies[i].sock);
-			proxies[i].sock = INVALID_SOCKET;
-		}
-	}
-}
-
-// Forward declaration used by the route-building helpers below.
-static void CL_BR_AddRoute(const char *proxylist, const char *label,
-                            float ping_ms, float loss_pct, qbool via_proxy);
-
-// --------------------------------------------
-// Score -- lower is better (includes loss).
-// --------------------------------------------
-static float CL_BR_Score(float ping_ms, float loss_pct)
-{
-	float o      = cl_connectbr_ping_orange.value > 0 ? cl_connectbr_ping_orange.value : 200.0f;
-	float w_ping = cl_connectbr_weight_ping.value  > 0 ? cl_connectbr_weight_ping.value  : 1.0f;
-	float w_loss = cl_connectbr_weight_loss.value  > 0 ? cl_connectbr_weight_loss.value  : 0.4f;
-	float norm_ping = ping_ms / (o * 2.0f);
-	if (norm_ping > 1.0f) norm_ping = 1.0f;
-	float norm_loss = loss_pct / 100.0f;
-	if (norm_loss > 1.0f) norm_loss = 1.0f;
-	return w_ping * norm_ping + w_loss * norm_loss;
-}
-
-static int CL_BR_RouteCompare(const void *a, const void *b)
-{
-	const route_t *ra = (const route_t *)a;
-	const route_t *rb = (const route_t *)b;
-	if (ra->score < rb->score) return -1;
-	if (ra->score > rb->score) return  1;
-	return 0;
-}
-
-// --------------------------------------------
-// Add a route (dedup by proxylist string).
-// Rejects if proxylist would be truncated.
-// --------------------------------------------
-static void CL_BR_AddRoute(const char *proxylist, const char *label,
-                            float ping_ms, float loss_pct, qbool via_proxy)
-{
-	int i;
-
-	if (br_route_count >= CONNECTBR_MAX_ROUTES) return;
-
-	if (strlen(proxylist) >= MAX_PROXYLIST) {
-		BR_Debug("route '%s' skipped: proxylist too long (%d chars)\n",
-		         label, (int)strlen(proxylist));
-		return;
-	}
-
-	for (i = 0; i < br_route_count; i++)
-		if (strcmp(br_routes[i].proxylist, proxylist) == 0) return;
-
-	strlcpy(br_routes[br_route_count].proxylist, proxylist, MAX_PROXYLIST);
-	strlcpy(br_routes[br_route_count].label,     label,     sizeof(br_routes[0].label));
-	br_routes[br_route_count].ping_ms   = ping_ms;
-	br_routes[br_route_count].loss_pct  = loss_pct;
-	br_routes[br_route_count].score     = CL_BR_Score(ping_ms, loss_pct);
-	br_routes[br_route_count].via_proxy = via_proxy;
-	br_routes[br_route_count].valid     = true;
-	br_route_count++;
-}
-
-// --------------------------------------------
-// Apply route and connect
-// --------------------------------------------
-static void CL_BR_ApplyRoute(int idx)
-{
-	route_t *r = &br_routes[idx];
-
-	Cvar_Set(&cl_proxyaddr, "");
-	if (r->proxylist[0])
-		Cvar_Set(&cl_proxyaddr, r->proxylist);
-
-	Com_Printf("\n&cf80connectbr:&r route #%d - %s\n", idx + 1, r->label);
-	Com_Printf("  ping: %s%.0fms&r  loss: %s%.1f%%&r\n",
-	           CL_BR_PingColor(r->ping_ms), r->ping_ms,
-	           CL_BR_LossColor(r->loss_pct), r->loss_pct);
-
-	if (idx + 1 < br_route_count)
-		Com_Printf("  type &cf80connectnext&r for route #%d (%s)\n",
-		           idx + 2, br_routes[idx + 1].label);
+	if (index + 1 < br_route_count)
+		Com_Printf("  type &cf80connectnext&r to try route #%d\n", index + 2);
 	else
 		Com_Printf("  no more routes available.\n");
 
 	Cbuf_AddText(va("connect %s\n", NET_AdrToString(br_target_addr)));
 }
 
-// --------------------------------------------
-// Thread proc -- todo o trabalho pesado roda aqui, fora da thread principal.
-// A thread principal dispara isso e retorna imediatamente (sem freeze).
-// --------------------------------------------
-static int CL_BR_MeasureProc(void *ignored)
+static void CL_BR_BuildRankingAndConnect(void)
 {
-	int i, j;
-	int timeout_ms = (int)cl_connectbr_timeout_ms.value;
-	int verbose    = (int)cl_connectbr_verbose.value;
+	int i;
+	int show;
 
-	proxy_t *p1       = NULL;
-	int      p1_count = 0;
-	proxy_t *p2       = NULL;
-	int      p2_count = 0;
-
-	if (timeout_ms <= 0) timeout_ms = 600;
-
-	// ══════════════════════════════════════════════════════════════════
-	// Step 1: ping tree (Dijkstra, se ja construido)
-	// ══════════════════════════════════════════════════════════════════
-	if (SB_PingTree_Built() && !SB_PingTree_IsBuilding()) {
-		int pathlen = SB_PingTree_GetPathLen(&br_target_addr);
-		if (pathlen > 0) {
-			int  total_ping_ms = 0;
-			char proxy_str[MAX_PROXYLIST];
-			char target_str[64];
-			proxy_str[0] = '\0';
-			CL_BR_AdrToStr(&br_target_addr, target_str, sizeof(target_str));
-			if (SB_PingTree_GetProxyString(&br_target_addr, proxy_str,
-			                               sizeof(proxy_str), &total_ping_ms)
-			    && proxy_str[0] && strcmp(proxy_str, target_str) != 0) {
-				float ping = (total_ping_ms > 0) ? (float)total_ping_ms : 1.0f;
-				char  lbl[128];
-				snprintf(lbl, sizeof(lbl), "ping tree (%d hop%s)",
-				         pathlen, pathlen > 1 ? "s" : "");
-				CL_BR_AddRoute(proxy_str, lbl, ping, 0.0f, true);
-			}
-		}
-	}
-
-	// ══════════════════════════════════════════════════════════════════
-	// Step 2: coletar proxies P1 do server browser
-	// ══════════════════════════════════════════════════════════════════
-	p1 = (proxy_t *)Q_malloc(CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
-	if (!p1) {
-		Com_Printf("connectbr: failed to allocate proxy list.\n");
-		goto step_direct;
-	}
-	memset(p1, 0, CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
-
-	SB_ServerList_Lock();
-	for (i = 0; i < serversn && p1_count < CONNECTBR_MAX_PROXIES; i++) {
-		server_data *s = servers[i];
-		int k; qbool dup = false;
-		if (!s || ntohs(s->address.port) != 30000) continue;
-		if (CL_BR_IsTarget(&s->address)) continue;
-		for (k = 0; k < p1_count && !dup; k++)
-			if (CL_BR_AdrEqual(&p1[k].addr, &s->address)) dup = true;
-		if (dup) continue;
-		p1[p1_count].addr   = s->address;
-		p1[p1_count].you_ms = (s->ping >= 0) ? s->ping : -1;
-		p1[p1_count].sock   = INVALID_SOCKET;
-		CL_BR_AdrToStr(&s->address, p1[p1_count].ip_str, sizeof(p1[0].ip_str));
-		strlcpy(p1[p1_count].name,
-		        s->display.name[0] ? s->display.name : p1[p1_count].ip_str,
-		        sizeof(p1[0].name));
-		p1_count++;
-	}
-	SB_ServerList_Unlock();
-
-	if (p1_count == 0) {
-		if (verbose >= 1)
-			Com_Printf("  No proxies found in server browser.\n");
-		goto step_direct;
-	}
-
-	if (verbose >= 1)
-		Com_Printf("  Testing %d prox%s...\n", p1_count, p1_count == 1 ? "y" : "ies");
-
-	// ══════════════════════════════════════════════════════════════════
-	// Step 3: pingstatus em batch para todos os P1s
-	// ══════════════════════════════════════════════════════════════════
-	CL_BR_BatchPingstatus(p1, p1_count, &br_target_addr, timeout_ms);
-
-	// ══════════════════════════════════════════════════════════════════
-	// Step 4: coletar candidatos P2 das respostas P1, query em batch
-	// ══════════════════════════════════════════════════════════════════
-	p2 = (proxy_t *)Q_malloc(CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
-	if (!p2) goto build_routes;
-	memset(p2, 0, CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
-
-	for (i = 0; i < p1_count; i++) {
-		if (!p1[i].replied) continue;
-		for (j = 0; j < p1[i].ps.count; j++) {
-			ps_entry_t *nb = &p1[i].ps.entries[j];
-			int k; qbool dup = false;
-
-			if (p2_count >= CONNECTBR_MAX_PROXIES) break;
-
-			if (ntohs(nb->addr.port) != 30000)           continue;
-			if (CL_BR_IsTarget(&nb->addr))               continue;
-			if (CL_BR_AdrEqual(&nb->addr, &p1[i].addr))  continue;
-			if (nb->addr.ip[0] == 0 && nb->addr.ip[1] == 0 &&
-			    nb->addr.ip[2] == 0 && nb->addr.ip[3] == 0) continue;
-
-			for (k = 0; k < p2_count && !dup; k++)
-				if (CL_BR_AdrEqual(&p2[k].addr, &nb->addr)) dup = true;
-			if (dup) continue;
-
-			p2[p2_count].addr   = nb->addr;
-			p2[p2_count].you_ms = -1;
-			p2[p2_count].sock   = INVALID_SOCKET;
-			CL_BR_AdrToStr(&nb->addr, p2[p2_count].ip_str, sizeof(p2[0].ip_str));
-			strlcpy(p2[p2_count].name, p2[p2_count].ip_str, sizeof(p2[0].name));
-			p2_count++;
-		}
-	}
-
-	if (p2_count > 0) {
-		BR_Debug("  %d P2 candidate(s) for 2-hop\n", p2_count);
-		CL_BR_BatchPingstatus(p2, p2_count, &br_target_addr, timeout_ms);
-	}
-
-	// ══════════════════════════════════════════════════════════════════
-	// Step 5: construir rotas
-	// ══════════════════════════════════════════════════════════════════
-build_routes:
-	{
-		int direct_ping = CL_BR_GetBrowserPing(&br_target_addr);
-		if (direct_ping <= 0) direct_ping = -1;
-
-		for (i = 0; i < p1_count; i++) {
-			char lbl[128];
-			int  p1_dest_ping;
-
-			if (!p1[i].replied) continue;
-
-			p1_dest_ping = (p1[i].ps.dest_ping >= 0)
-			               ? p1[i].ps.dest_ping : direct_ping;
-
-			/* 1-hop: you -> P1 -> dest */
-			if (p1_dest_ping >= 0) {
-				int   total     = p1[i].you_ms + p1_dest_ping;
-				qbool estimated = (p1[i].ps.dest_ping < 0);
-				snprintf(lbl, sizeof(lbl), "via %s [1 hop%s]",
-				         p1[i].name, estimated ? " ~est" : "");
-				CL_BR_AddRoute(p1[i].ip_str, lbl, (float)total, p1[i].loss_pct, true);
-				if (verbose >= 1)
-					Com_Printf("  [%s] %s%dms&r loss=%.0f%% (you %dms + proxy->dest %dms%s)\n",
-					           p1[i].name, CL_BR_PingColor((float)total), total,
-					           p1[i].loss_pct, p1[i].you_ms, p1_dest_ping,
-					           estimated ? " ~est" : "");
-			}
-
-			/* 2-hop: so usa P1 como intermediario se voce->P1 < ping direto.
-			 * Se nao temos ping direto (direct_ping==-1), nao filtra -- tenta tudo. */
-			if (!p2) continue;
-			if (direct_ping > 0 && p1[i].you_ms >= direct_ping) continue;
-
-			for (j = 0; j < p1[i].ps.count; j++) {
-				ps_entry_t *nb = &p1[i].ps.entries[j];
-				int k, total2, p2_dest_ping;
-				qbool estimated2;
-				char proxylist[MAX_PROXYLIST];
-
-				if (ntohs(nb->addr.port) != 30000)           continue;
-				if (CL_BR_IsTarget(&nb->addr))               continue;
-				if (CL_BR_AdrEqual(&nb->addr, &p1[i].addr))  continue;
-
-				for (k = 0; k < p2_count; k++)
-					if (CL_BR_AdrEqual(&p2[k].addr, &nb->addr)) break;
-				if (k >= p2_count || !p2[k].replied) continue;
-
-				p2_dest_ping = (p2[k].ps.dest_ping >= 0)
-				               ? p2[k].ps.dest_ping : direct_ping;
-				if (p2_dest_ping < 0) continue;
-
-				estimated2 = (p2[k].ps.dest_ping < 0);
-				total2 = p1[i].you_ms + nb->dist_ms + p2_dest_ping;
-
-				snprintf(proxylist, sizeof(proxylist), "%s@%s",
-				         p1[i].ip_str, p2[k].ip_str);
-				snprintf(lbl, sizeof(lbl), "via %s -> %s [2 hops%s]",
-				         p1[i].name, p2[k].ip_str, estimated2 ? " ~est" : "");
-				CL_BR_AddRoute(proxylist, lbl, (float)total2, p2[k].loss_pct, true);
-
-				if (verbose >= 1)
-					Com_Printf("  [%s -> %s] %s%dms&r loss=%.0f%%  "
-					           "(you %dms + P1->P2 %dms + P2->dest %dms%s) &cf802 hops&r\n",
-					           p1[i].name, p2[k].ip_str,
-					           CL_BR_PingColor((float)total2), total2,
-					           p2[k].loss_pct,
-					           p1[i].you_ms, nb->dist_ms, p2_dest_ping,
-					           estimated2 ? " ~est" : "");
-			}
-		}
-	}
-
-	// ══════════════════════════════════════════════════════════════════
-	// Step 6: conexao direta
-	// ══════════════════════════════════════════════════════════════════
-step_direct:
-	{
-		int dp = CL_BR_GetBrowserPing(&br_target_addr);
-		if (dp > 0) {
-			if (verbose >= 1)
-				Com_Printf("  [direct] %s%dms&r\n", CL_BR_PingColor((float)dp), dp);
-			CL_BR_AddRoute("", "direct", (float)dp, 0.0f, false);
-		}
-	}
-
-	Q_free(p1);
-	Q_free(p2);
-	br_measuring = false;
-
-	if (br_route_count == 0) {
-		Com_Printf("connectbr: no routes found.\n");
-		return 0;
-	}
-
-	qsort(br_routes, br_route_count, sizeof(route_t), CL_BR_RouteCompare);
-
-	if (br_route_count > 10)
-		br_route_count = 10;
-
-	/* Monta ranking no buffer -- sera impresso pela thread principal em CL_ConnectBR_Frame */
-	{
-		int  show = (br_route_count < 6) ? br_route_count : 6;
-		char tmp[256];
-		br_ranking_buf[0] = '\0';
-		snprintf(tmp, sizeof(tmp), "\n&cf80connectbr: top %d routes&r\n", show);
-		strlcat(br_ranking_buf, tmp, sizeof(br_ranking_buf));
-		for (i = 0; i < show; i++) {
-			snprintf(tmp, sizeof(tmp), "  &cf80#%d&r  %s%.0fms&r  %s%.1f%%&r  %s\n",
-			         i + 1,
-			         CL_BR_PingColor(br_routes[i].ping_ms), br_routes[i].ping_ms,
-			         CL_BR_LossColor(br_routes[i].loss_pct), br_routes[i].loss_pct,
-			         br_routes[i].label);
-			strlcat(br_ranking_buf, tmp, sizeof(br_ranking_buf));
-		}
-	}
-
+	br_pending = false;
+	br_route_count = SB_PingTree_GetRoutes(&br_target_addr, br_routes,
+	                                       SB_ROUTE_MAX_ALTERNATIVES);
 	br_current_route = 0;
-	br_active        = true;
-	br_done          = true;   /* sinaliza thread principal para imprimir e conectar */
-	return 0;
-}
+	br_active = br_route_count > 0;
 
-// --------------------------------------------
-// PUBLIC: connectbr <address>
-// Valida argumentos, seta estado e dispara thread.
-// Retorna imediatamente -- sem freeze.
-// --------------------------------------------
-void CL_Connect_BestRoute_f(void)
-{
-	const char *addr;
-
-	if (br_measuring) {
-		Com_Printf("connectbr: measurement already in progress.\n");
+	if (!br_route_count) {
+		Com_Printf("connectbr: sb_findroutes found no route to %s.\n",
+		           NET_AdrToString(br_target_addr));
 		return;
 	}
+
+	show = min(br_route_count, CONNECTBR_DISPLAY_ROUTES);
+	Com_Printf("\n&cf80connectbr: top %d routes from sb_findroutes&r\n", show);
+	for (i = 0; i < show; i++) {
+		if (br_routes[i].proxylist[0])
+			Com_Printf("  &cf80#%d&r  %dms  %d hop%s  %s\n", i + 1,
+			           br_routes[i].total_cost_ms, br_routes[i].hops,
+			           br_routes[i].hops == 1 ? "" : "s", br_routes[i].proxylist);
+		else
+			Com_Printf("  &cf80#%d&r  %dms  direct\n", i + 1,
+			           br_routes[i].total_cost_ms);
+	}
+
+	if (cl_connectbr_debug.integer)
+		Com_Printf("[connectbr] %d cached alternative(s); no additional proxy scan\n",
+		           br_route_count);
+
+	CL_BR_ApplyRoute(0);
+}
+
+void CL_Connect_BestRoute_f(void)
+{
+	const char *address;
 
 	if (Cmd_Argc() != 2) {
 		Com_Printf("Usage: connectbr <address>\n");
-		Com_Printf("  Tests 1-hop and 2-hop proxy routes and connects via the best one.\n");
-		Com_Printf("  Use connectnext to try the next route.\n");
+		Com_Printf("  Uses the routes already measured by sb_findroutes.\n");
+		Com_Printf("  Use connectnext to try the next cached route.\n");
 		return;
 	}
 
-	addr = Cmd_Argv(1);
-	if (!addr || !*addr)                    { Com_Printf("connectbr: empty address\n");    return; }
-	if (strlen(addr) > MAX_ADDRESS_LENGTH)  { Com_Printf("connectbr: address too long\n"); return; }
-
-	if (!NET_StringToAdr(addr, &br_target_addr)) {
-		Com_Printf("connectbr: invalid address '%s'\n", addr);
+	address = Cmd_Argv(1);
+	if (!address || !address[0]) {
+		Com_Printf("connectbr: empty address\n");
 		return;
 	}
-	if (br_target_addr.port == 0)
+	if (strlen(address) > MAX_ADDRESS_LENGTH) {
+		Com_Printf("connectbr: address too long\n");
+		return;
+	}
+	if (!NET_StringToAdr(address, &br_target_addr)) {
+		Com_Printf("connectbr: invalid address '%s'\n", address);
+		return;
+	}
+	if (!br_target_addr.port)
 		br_target_addr.port = htons(27500);
 
+	br_active = false;
+	br_route_count = 0;
+	br_current_route = 0;
+	Cvar_Set(&cl_proxyaddr, "");
+
 	if (SB_PingTree_IsBuilding()) {
-		Com_Printf("connectbr: ping tree still building -- retry later.\n");
+		br_pending = true;
+		Com_Printf("connectbr: waiting for sb_findroutes to finish...\n");
+		return;
+	}
+	if (!SB_PingTree_Built()) {
+		br_pending = true;
+		Com_Printf("connectbr: building sb_findroutes graph...\n");
+		SB_PingTree_Build();
 		return;
 	}
 
-	br_measuring     = true;
-	br_route_count   = 0;
-	br_current_route = 0;
-	br_active        = false;
-	br_done          = false;
-	br_ranking_buf[0] = '\0';
-	Cvar_Set(&cl_proxyaddr, "");
-
-	if ((int)cl_connectbr_verbose.value >= 1)
-		Com_Printf("\n&cf80connectbr:&r testing routes to %s\n", addr);
-
-	if (Sys_CreateDetachedThread(CL_BR_MeasureProc, NULL) < 0) {
-		Com_Printf("connectbr: failed to create measurement thread.\n");
-		br_measuring = false;
-	}
+	CL_BR_BuildRankingAndConnect();
 }
 
-// --------------------------------------------
-// PUBLIC: connectnext
-// --------------------------------------------
 void CL_Connect_Next_f(void)
 {
-	if (!br_active || br_route_count == 0) {
-		Com_Printf("connectnext: no active connectbr session.\n");
+	if (!br_active || !br_route_count) {
+		Com_Printf("connectnext: no cached connectbr ranking.\n");
 		Com_Printf("  Use 'connectbr <address>' first.\n");
 		return;
 	}
 
-	br_current_route++;
-
-	if (br_current_route >= br_route_count) {
+	if (br_current_route + 1 >= br_route_count) {
 		Com_Printf("connectnext: no more routes (tried all %d).\n", br_route_count);
 		br_active = false;
 		return;
 	}
 
+	br_current_route++;
 	Host_EndGame();
 	CL_BR_ApplyRoute(br_current_route);
 }
 
-// --------------------------------------------
-// PUBLIC: CL_ConnectBR_Frame
-// Chamada pela thread principal a cada frame.
-// Verifica se a thread de medicao terminou e,
-// se sim, imprime o ranking e conecta -- tudo
-// na thread principal, sem race condition.
-// --------------------------------------------
 void CL_ConnectBR_Frame(void)
 {
-	if (!br_done) return;
-	br_done = false;
-
-	if (br_route_count == 0) return;
-
-	/* Imprime ranking aqui -- thread principal, Com_Printf seguro */
-	if (br_ranking_buf[0])
-		Com_Printf("%s", br_ranking_buf);
-
-	CL_BR_ApplyRoute(0);
+	if (br_pending && !SB_PingTree_IsBuilding() && SB_PingTree_Built())
+		CL_BR_BuildRankingAndConnect();
 }
 
-// --------------------------------------------
-// PUBLIC: register cvars
-// --------------------------------------------
 void CL_ConnectBR_Init(void)
 {
 	Cvar_SetCurrentGroup(CVAR_GROUP_NETWORK);
-	Cvar_Register(&cl_connectbr_timeout_ms);
-	Cvar_Register(&cl_connectbr_ping_green);
-	Cvar_Register(&cl_connectbr_ping_yellow);
-	Cvar_Register(&cl_connectbr_ping_orange);
-	Cvar_Register(&cl_connectbr_weight_ping);
-	Cvar_Register(&cl_connectbr_weight_loss);
-	Cvar_Register(&cl_connectbr_test_packets);
-	Cvar_Register(&cl_connectbr_packet_delay);
 	Cvar_Register(&cl_connectbr_verbose);
 	Cvar_Register(&cl_connectbr_debug);
 	Cvar_ResetCurrentGroup();

--- a/src/cl_connectbr.c
+++ b/src/cl_connectbr.c
@@ -36,12 +36,12 @@ static qbool br_pending;
 static const char *CL_BR_RouteColor(int cost_ms)
 {
 	if (cost_ms <= 80)
-		return "&c80ff80";
+		return "&c0f0";
 	if (cost_ms <= 140)
-		return "&cffef80";
+		return "&caf0";
 	if (cost_ms <= 220)
-		return "&cffff80";
-	return "&cff8080";
+		return "&cff0";
+	return "&cf00";
 }
 
 static void CL_BR_ApplyRoute(int index)

--- a/src/cl_connectbr.c
+++ b/src/cl_connectbr.c
@@ -1,0 +1,772 @@
+/*
+Copyright (C) 2024 unezQuake team
+
+cl_connectbr.c - Smart route selection for connectbr/connectnext commands
+
+Multi-hop logic:
+  Batch-queries all proxy candidates simultaneously (one socket each).
+  Collects all pingstatus replies in a single select() loop -- total wait
+  is ONE timeout window regardless of how many proxies are tested.
+
+  1-hop:  you -> P1 -> dest
+  2-hop:  you -> P1 -> P2 -> dest
+          P2 candidates are proxies (port 30000) found in P1's pingstatus.
+          A second batch round queries all P2 candidates.
+
+CVars:
+  cl_connectbr_timeout_ms     - pingstatus reply timeout in ms (default 600)
+  cl_connectbr_ping_green     - green ping threshold (default 40)
+  cl_connectbr_ping_yellow    - yellow ping threshold (default 80)
+  cl_connectbr_ping_orange    - orange/max playable threshold (default 200)
+  cl_connectbr_weight_ping    - score weight for ping (default 1.0)
+  cl_connectbr_weight_loss    - score weight for loss (default 0.4)
+  cl_connectbr_test_packets   - number of pingstatus packets to send for loss (default 10)
+  cl_connectbr_packet_delay   - delay between packets in ms (default 15)
+  cl_connectbr_verbose        - 0=quiet 1=normal 2=debug (default 1)
+*/
+
+#include "quakedef.h"
+#include "EX_browser.h"
+#include "cl_connectbr.h"
+
+// cl_proxyaddr is declared in cl_main.c
+extern cvar_t cl_proxyaddr;
+
+// --------------------------------------------
+// CVars
+// --------------------------------------------
+cvar_t cl_connectbr_timeout_ms    = {"cl_connectbr_timeout_ms",    "600",  CVAR_ARCHIVE};
+cvar_t cl_connectbr_ping_green    = {"cl_connectbr_ping_green",    "40",   CVAR_ARCHIVE};
+cvar_t cl_connectbr_ping_yellow   = {"cl_connectbr_ping_yellow",   "80",   CVAR_ARCHIVE};
+cvar_t cl_connectbr_ping_orange   = {"cl_connectbr_ping_orange",   "200",  CVAR_ARCHIVE};
+cvar_t cl_connectbr_weight_ping   = {"cl_connectbr_weight_ping",   "1.0",  CVAR_ARCHIVE};
+cvar_t cl_connectbr_weight_loss   = {"cl_connectbr_weight_loss",   "0.4",  CVAR_ARCHIVE};
+cvar_t cl_connectbr_test_packets  = {"cl_connectbr_test_packets",  "10",   CVAR_ARCHIVE};
+cvar_t cl_connectbr_packet_delay  = {"cl_connectbr_packet_delay",  "15",   CVAR_ARCHIVE};
+cvar_t cl_connectbr_verbose       = {"cl_connectbr_verbose",       "1",    CVAR_ARCHIVE};
+cvar_t cl_connectbr_debug         = {"cl_connectbr_debug",         "0",    CVAR_ARCHIVE};
+
+// --------------------------------------------
+// Constants
+// --------------------------------------------
+#define CONNECTBR_MAX_PROXIES     128  /* 91 proxies qwfwd ativos globalmente (Mar/2026) */
+#define CONNECTBR_MAX_NEIGHBORS   64
+/* max rotas = 64 proxies (1-hop) + combinacoes 2-hop + 1 direta.
+ * 256 cobre o pior caso pratico com folga (route_t ~600 bytes, total ~150KB). */
+#define CONNECTBR_MAX_ROUTES      256
+#define MAX_PROXYLIST             256
+#define MAX_ADDRESS_LENGTH        128
+
+#define BR_Debug(...) \
+	do { if (cl_connectbr_debug.value) Com_Printf("[connectbr] " __VA_ARGS__); } while(0)
+
+// --------------------------------------------
+// Types
+// --------------------------------------------
+typedef struct {
+	char    proxylist[MAX_PROXYLIST];
+	char    label[128];
+	float   ping_ms;
+	float   loss_pct;
+	float   score;
+	qbool   via_proxy;
+	qbool   valid;
+} route_t;
+
+typedef struct {
+	netadr_t addr;
+	int      dist_ms;
+} ps_entry_t;
+
+typedef struct {
+	ps_entry_t entries[CONNECTBR_MAX_NEIGHBORS];
+	int        count;
+	int        dest_ping;   /* proxy's ping to dest, -1 if not in reply */
+} ps_reply_t;
+
+typedef struct {
+	netadr_t  addr;
+	char      ip_str[64];
+	char      name[128];
+	int       you_ms;       /* you -> this proxy (from browser or measured) */
+	float     loss_pct;     /* packet loss to destination (for pingstatus) */
+	socket_t  sock;
+	qbool     replied;      /* received at least one pingstatus reply? */
+	ps_reply_t ps;
+} proxy_t;
+
+// --------------------------------------------
+// State
+// --------------------------------------------
+static route_t   br_routes[CONNECTBR_MAX_ROUTES];
+static int       br_route_count   = 0;
+static int       br_current_route = 0;
+static netadr_t  br_target_addr;
+static qbool     br_active        = false;
+static qbool     br_measuring     = false;
+static qbool     br_done          = false;
+static char      br_ranking_buf[4096];
+
+// --------------------------------------------
+// Colour helpers
+// --------------------------------------------
+static const char *CL_BR_PingColor(float ms)
+{
+	int g = (int)cl_connectbr_ping_green.value;
+	int y = (int)cl_connectbr_ping_yellow.value;
+	int o = (int)cl_connectbr_ping_orange.value;
+	if (g <= 0) g = 40;
+	if (y <= 0) y = 80;
+	if (o <= 0) o = 200;
+	if (ms <= g) return "&c0f0";
+	if (ms <= y) return "&cff0";
+	if (ms <= o) return "&cfa0";
+	return "&cf00";
+}
+
+static const char *CL_BR_LossColor(float pct)
+{
+	if (pct <= 0) return "&c0f0";
+	if (pct <= 5) return "&cff0";
+	return "&cf00";
+}
+
+// --------------------------------------------
+// Helpers
+// --------------------------------------------
+static void CL_BR_AdrToStr(const netadr_t *a, char *buf, size_t bufsz)
+{
+	snprintf(buf, bufsz, "%d.%d.%d.%d:%d",
+	         a->ip[0], a->ip[1], a->ip[2], a->ip[3], (int)ntohs(a->port));
+}
+
+static qbool CL_BR_IsTarget(const netadr_t *a)
+{
+	return (memcmp(a->ip, br_target_addr.ip, 4) == 0 &&
+	        a->port == br_target_addr.port);
+}
+
+static qbool CL_BR_AdrEqual(const netadr_t *a, const netadr_t *b)
+{
+	return (memcmp(a->ip, b->ip, 4) == 0 && a->port == b->port);
+}
+
+static int CL_BR_GetBrowserPing(const netadr_t *dest)
+{
+	int i, best = -1;
+	SB_ServerList_Lock();
+	for (i = 0; i < serversn; i++) {
+		if (NET_CompareAdr(servers[i]->address, *dest) && servers[i]->ping >= 0) {
+			best = servers[i]->ping;
+			break;
+		}
+	}
+	SB_ServerList_Unlock();
+	return best;
+}
+
+// --------------------------------------------
+// Parse a raw pingstatus reply buffer.
+// --------------------------------------------
+static void CL_BR_ParsePingstatus(const byte *buf, int len,
+                                   const netadr_t *dest, ps_reply_t *ps)
+{
+	const byte *p   = buf;
+	const byte *end = buf + len;
+
+	ps->count     = 0;
+	ps->dest_ping = -1;
+
+	while (p + 8 <= end) {
+		unsigned short port_net;
+		short dist_raw;
+		int   dist_ms;
+
+		memcpy(&port_net, p + 4, 2);
+		memcpy(&dist_raw, p + 6, 2);
+		dist_ms = (int)(short)LittleShort(dist_raw);
+
+		if (dist_ms >= 0) {
+			if (dest &&
+			    memcmp(p, dest->ip, 4) == 0 &&
+			    memcmp(p + 4, &dest->port, 2) == 0) {
+				ps->dest_ping = dist_ms;
+			}
+			if (ps->count < CONNECTBR_MAX_NEIGHBORS) {
+				ps_entry_t *e = &ps->entries[ps->count++];
+				e->addr.type = NA_IP;
+				memcpy(e->addr.ip, p, 4);
+				e->addr.port = port_net;
+				e->dist_ms   = dist_ms;
+			}
+		}
+		p += 8;
+	}
+}
+
+// --------------------------------------------
+// Batch pingstatus -- sends to all proxies simultaneously,
+// measures you->proxy RTT from the first reply timing,
+// counts multiple replies to compute loss.
+// Total blocking time = timeout_ms, regardless of proxy count.
+// --------------------------------------------
+static void CL_BR_BatchPingstatus(proxy_t *proxies, int count,
+                                   const netadr_t *dest, int timeout_ms)
+{
+	const char *packet      = "\xff\xff\xff\xffpingstatus";
+	int         packet_count = (int)cl_connectbr_test_packets.value;
+	double     *send_times;
+	int        *recv_count;
+	int         i, pkt;
+	double      deadline;
+	struct timeval tv;
+
+	if (packet_count < 1)  packet_count = 1;
+	if (packet_count > 20) packet_count = 20;
+	if (timeout_ms <= 0)   timeout_ms   = 600;
+
+	send_times = (double *)Q_malloc(count * sizeof(double));
+	recv_count = (int    *)Q_malloc(count * sizeof(int));
+	if (!send_times || !recv_count) {
+		Q_free(send_times);
+		Q_free(recv_count);
+		return;
+	}
+	memset(recv_count, 0, count * sizeof(int));
+
+	/* open one socket per proxy, record send time, send all packets */
+	for (i = 0; i < count; i++) {
+		struct sockaddr_storage addr_to;
+		proxies[i].replied      = false;
+		proxies[i].loss_pct     = 100.0f;
+		proxies[i].ps.count     = 0;
+		proxies[i].ps.dest_ping = -1;
+		send_times[i]           = 0;
+
+		proxies[i].sock = UDP_OpenSocket(PORT_ANY);
+		if (proxies[i].sock == INVALID_SOCKET) continue;
+
+		NetadrToSockadr(&proxies[i].addr, &addr_to);
+		send_times[i] = Sys_DoubleTime();
+		for (pkt = 0; pkt < packet_count; pkt++) {
+			sendto(proxies[i].sock, packet, strlen(packet), 0,
+			       (struct sockaddr *)&addr_to, sizeof(struct sockaddr));
+		}
+	}
+
+	deadline = Sys_DoubleTime() + timeout_ms / 1000.0;
+
+	while (Sys_DoubleTime() < deadline) {
+		fd_set fd;
+		int    maxsock = 0;
+		qbool  any     = false;
+
+		FD_ZERO(&fd);
+		for (i = 0; i < count; i++) {
+			/* keep listening until we've received all expected replies or timed out */
+			if (recv_count[i] < packet_count && proxies[i].sock != INVALID_SOCKET) {
+				FD_SET(proxies[i].sock, &fd);
+				if ((int)proxies[i].sock > maxsock)
+					maxsock = (int)proxies[i].sock;
+				any = true;
+			}
+		}
+		if (!any) break;
+
+		tv.tv_sec = 0; tv.tv_usec = 20000;
+		if (select(maxsock + 1, &fd, NULL, NULL, &tv) <= 0) continue;
+
+		for (i = 0; i < count; i++) {
+			if (recv_count[i] < packet_count
+			    && proxies[i].sock != INVALID_SOCKET
+			    && FD_ISSET(proxies[i].sock, &fd)) {
+				byte buf[8 * 512];
+				struct sockaddr_storage from;
+				socklen_t from_len = sizeof(from);
+				double    now      = Sys_DoubleTime();
+				int ret = recvfrom(proxies[i].sock, (char *)buf, sizeof(buf), 0,
+				                   (struct sockaddr *)&from, &from_len);
+				if (ret > 5 && memcmp(buf, "\xff\xff\xff\xffn", 5) == 0) {
+					recv_count[i]++;
+					if (!proxies[i].replied) {
+						/* first reply: parse pingstatus data */
+						CL_BR_ParsePingstatus(buf + 5, ret - 5, dest, &proxies[i].ps);
+						proxies[i].replied = true;
+						/* measure you->proxy RTT from pingstatus round-trip
+						   (use this only if browser didn't already have a ping) */
+						if (proxies[i].you_ms < 0 && send_times[i] > 0) {
+							int ms = (int)((now - send_times[i]) * 1000.0);
+							proxies[i].you_ms = (ms < 1) ? 1 : ms;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/* compute packet loss for each proxy */
+	for (i = 0; i < count; i++) {
+		if (proxies[i].replied && recv_count[i] > 0) {
+			float loss = 100.0f * (1.0f - (float)recv_count[i] / (float)packet_count);
+			proxies[i].loss_pct = (loss < 0) ? 0 : loss;
+		}
+	}
+
+	Q_free(send_times);
+	Q_free(recv_count);
+
+	for (i = 0; i < count; i++) {
+		if (proxies[i].sock != INVALID_SOCKET) {
+			closesocket(proxies[i].sock);
+			proxies[i].sock = INVALID_SOCKET;
+		}
+	}
+}
+
+// Forward declaration used by the route-building helpers below.
+static void CL_BR_AddRoute(const char *proxylist, const char *label,
+                            float ping_ms, float loss_pct, qbool via_proxy);
+
+// --------------------------------------------
+// Score -- lower is better (includes loss).
+// --------------------------------------------
+static float CL_BR_Score(float ping_ms, float loss_pct)
+{
+	float o      = cl_connectbr_ping_orange.value > 0 ? cl_connectbr_ping_orange.value : 200.0f;
+	float w_ping = cl_connectbr_weight_ping.value  > 0 ? cl_connectbr_weight_ping.value  : 1.0f;
+	float w_loss = cl_connectbr_weight_loss.value  > 0 ? cl_connectbr_weight_loss.value  : 0.4f;
+	float norm_ping = ping_ms / (o * 2.0f);
+	if (norm_ping > 1.0f) norm_ping = 1.0f;
+	float norm_loss = loss_pct / 100.0f;
+	if (norm_loss > 1.0f) norm_loss = 1.0f;
+	return w_ping * norm_ping + w_loss * norm_loss;
+}
+
+static int CL_BR_RouteCompare(const void *a, const void *b)
+{
+	const route_t *ra = (const route_t *)a;
+	const route_t *rb = (const route_t *)b;
+	if (ra->score < rb->score) return -1;
+	if (ra->score > rb->score) return  1;
+	return 0;
+}
+
+// --------------------------------------------
+// Add a route (dedup by proxylist string).
+// Rejects if proxylist would be truncated.
+// --------------------------------------------
+static void CL_BR_AddRoute(const char *proxylist, const char *label,
+                            float ping_ms, float loss_pct, qbool via_proxy)
+{
+	int i;
+
+	if (br_route_count >= CONNECTBR_MAX_ROUTES) return;
+
+	if (strlen(proxylist) >= MAX_PROXYLIST) {
+		BR_Debug("route '%s' skipped: proxylist too long (%d chars)\n",
+		         label, (int)strlen(proxylist));
+		return;
+	}
+
+	for (i = 0; i < br_route_count; i++)
+		if (strcmp(br_routes[i].proxylist, proxylist) == 0) return;
+
+	strlcpy(br_routes[br_route_count].proxylist, proxylist, MAX_PROXYLIST);
+	strlcpy(br_routes[br_route_count].label,     label,     sizeof(br_routes[0].label));
+	br_routes[br_route_count].ping_ms   = ping_ms;
+	br_routes[br_route_count].loss_pct  = loss_pct;
+	br_routes[br_route_count].score     = CL_BR_Score(ping_ms, loss_pct);
+	br_routes[br_route_count].via_proxy = via_proxy;
+	br_routes[br_route_count].valid     = true;
+	br_route_count++;
+}
+
+// --------------------------------------------
+// Apply route and connect
+// --------------------------------------------
+static void CL_BR_ApplyRoute(int idx)
+{
+	route_t *r = &br_routes[idx];
+
+	Cvar_Set(&cl_proxyaddr, "");
+	if (r->proxylist[0])
+		Cvar_Set(&cl_proxyaddr, r->proxylist);
+
+	Com_Printf("\n&cf80connectbr:&r route #%d - %s\n", idx + 1, r->label);
+	Com_Printf("  ping: %s%.0fms&r  loss: %s%.1f%%&r\n",
+	           CL_BR_PingColor(r->ping_ms), r->ping_ms,
+	           CL_BR_LossColor(r->loss_pct), r->loss_pct);
+
+	if (idx + 1 < br_route_count)
+		Com_Printf("  type &cf80connectnext&r for route #%d (%s)\n",
+		           idx + 2, br_routes[idx + 1].label);
+	else
+		Com_Printf("  no more routes available.\n");
+
+	Cbuf_AddText(va("connect %s\n", NET_AdrToString(br_target_addr)));
+}
+
+// --------------------------------------------
+// Thread proc -- todo o trabalho pesado roda aqui, fora da thread principal.
+// A thread principal dispara isso e retorna imediatamente (sem freeze).
+// --------------------------------------------
+static int CL_BR_MeasureProc(void *ignored)
+{
+	int i, j;
+	int timeout_ms = (int)cl_connectbr_timeout_ms.value;
+	int verbose    = (int)cl_connectbr_verbose.value;
+
+	proxy_t *p1       = NULL;
+	int      p1_count = 0;
+	proxy_t *p2       = NULL;
+	int      p2_count = 0;
+
+	if (timeout_ms <= 0) timeout_ms = 600;
+
+	// ══════════════════════════════════════════════════════════════════
+	// Step 1: ping tree (Dijkstra, se ja construido)
+	// ══════════════════════════════════════════════════════════════════
+	if (SB_PingTree_Built() && !SB_PingTree_IsBuilding()) {
+		int pathlen = SB_PingTree_GetPathLen(&br_target_addr);
+		if (pathlen > 0) {
+			int  total_ping_ms = 0;
+			char proxy_str[MAX_PROXYLIST];
+			char target_str[64];
+			proxy_str[0] = '\0';
+			CL_BR_AdrToStr(&br_target_addr, target_str, sizeof(target_str));
+			if (SB_PingTree_GetProxyString(&br_target_addr, proxy_str,
+			                               sizeof(proxy_str), &total_ping_ms)
+			    && proxy_str[0] && strcmp(proxy_str, target_str) != 0) {
+				float ping = (total_ping_ms > 0) ? (float)total_ping_ms : 1.0f;
+				char  lbl[128];
+				snprintf(lbl, sizeof(lbl), "ping tree (%d hop%s)",
+				         pathlen, pathlen > 1 ? "s" : "");
+				CL_BR_AddRoute(proxy_str, lbl, ping, 0.0f, true);
+			}
+		}
+	}
+
+	// ══════════════════════════════════════════════════════════════════
+	// Step 2: coletar proxies P1 do server browser
+	// ══════════════════════════════════════════════════════════════════
+	p1 = (proxy_t *)Q_malloc(CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
+	if (!p1) {
+		Com_Printf("connectbr: failed to allocate proxy list.\n");
+		goto step_direct;
+	}
+	memset(p1, 0, CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
+
+	SB_ServerList_Lock();
+	for (i = 0; i < serversn && p1_count < CONNECTBR_MAX_PROXIES; i++) {
+		server_data *s = servers[i];
+		int k; qbool dup = false;
+		if (!s || ntohs(s->address.port) != 30000) continue;
+		if (CL_BR_IsTarget(&s->address)) continue;
+		for (k = 0; k < p1_count && !dup; k++)
+			if (CL_BR_AdrEqual(&p1[k].addr, &s->address)) dup = true;
+		if (dup) continue;
+		p1[p1_count].addr   = s->address;
+		p1[p1_count].you_ms = (s->ping >= 0) ? s->ping : -1;
+		p1[p1_count].sock   = INVALID_SOCKET;
+		CL_BR_AdrToStr(&s->address, p1[p1_count].ip_str, sizeof(p1[0].ip_str));
+		strlcpy(p1[p1_count].name,
+		        s->display.name[0] ? s->display.name : p1[p1_count].ip_str,
+		        sizeof(p1[0].name));
+		p1_count++;
+	}
+	SB_ServerList_Unlock();
+
+	if (p1_count == 0) {
+		if (verbose >= 1)
+			Com_Printf("  No proxies found in server browser.\n");
+		goto step_direct;
+	}
+
+	if (verbose >= 1)
+		Com_Printf("  Testing %d prox%s...\n", p1_count, p1_count == 1 ? "y" : "ies");
+
+	// ══════════════════════════════════════════════════════════════════
+	// Step 3: pingstatus em batch para todos os P1s
+	// ══════════════════════════════════════════════════════════════════
+	CL_BR_BatchPingstatus(p1, p1_count, &br_target_addr, timeout_ms);
+
+	// ══════════════════════════════════════════════════════════════════
+	// Step 4: coletar candidatos P2 das respostas P1, query em batch
+	// ══════════════════════════════════════════════════════════════════
+	p2 = (proxy_t *)Q_malloc(CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
+	if (!p2) goto build_routes;
+	memset(p2, 0, CONNECTBR_MAX_PROXIES * sizeof(proxy_t));
+
+	for (i = 0; i < p1_count; i++) {
+		if (!p1[i].replied) continue;
+		for (j = 0; j < p1[i].ps.count; j++) {
+			ps_entry_t *nb = &p1[i].ps.entries[j];
+			int k; qbool dup = false;
+
+			if (p2_count >= CONNECTBR_MAX_PROXIES) break;
+
+			if (ntohs(nb->addr.port) != 30000)           continue;
+			if (CL_BR_IsTarget(&nb->addr))               continue;
+			if (CL_BR_AdrEqual(&nb->addr, &p1[i].addr))  continue;
+			if (nb->addr.ip[0] == 0 && nb->addr.ip[1] == 0 &&
+			    nb->addr.ip[2] == 0 && nb->addr.ip[3] == 0) continue;
+
+			for (k = 0; k < p2_count && !dup; k++)
+				if (CL_BR_AdrEqual(&p2[k].addr, &nb->addr)) dup = true;
+			if (dup) continue;
+
+			p2[p2_count].addr   = nb->addr;
+			p2[p2_count].you_ms = -1;
+			p2[p2_count].sock   = INVALID_SOCKET;
+			CL_BR_AdrToStr(&nb->addr, p2[p2_count].ip_str, sizeof(p2[0].ip_str));
+			strlcpy(p2[p2_count].name, p2[p2_count].ip_str, sizeof(p2[0].name));
+			p2_count++;
+		}
+	}
+
+	if (p2_count > 0) {
+		BR_Debug("  %d P2 candidate(s) for 2-hop\n", p2_count);
+		CL_BR_BatchPingstatus(p2, p2_count, &br_target_addr, timeout_ms);
+	}
+
+	// ══════════════════════════════════════════════════════════════════
+	// Step 5: construir rotas
+	// ══════════════════════════════════════════════════════════════════
+build_routes:
+	{
+		int direct_ping = CL_BR_GetBrowserPing(&br_target_addr);
+		if (direct_ping <= 0) direct_ping = -1;
+
+		for (i = 0; i < p1_count; i++) {
+			char lbl[128];
+			int  p1_dest_ping;
+
+			if (!p1[i].replied) continue;
+
+			p1_dest_ping = (p1[i].ps.dest_ping >= 0)
+			               ? p1[i].ps.dest_ping : direct_ping;
+
+			/* 1-hop: you -> P1 -> dest */
+			if (p1_dest_ping >= 0) {
+				int   total     = p1[i].you_ms + p1_dest_ping;
+				qbool estimated = (p1[i].ps.dest_ping < 0);
+				snprintf(lbl, sizeof(lbl), "via %s [1 hop%s]",
+				         p1[i].name, estimated ? " ~est" : "");
+				CL_BR_AddRoute(p1[i].ip_str, lbl, (float)total, p1[i].loss_pct, true);
+				if (verbose >= 1)
+					Com_Printf("  [%s] %s%dms&r loss=%.0f%% (you %dms + proxy->dest %dms%s)\n",
+					           p1[i].name, CL_BR_PingColor((float)total), total,
+					           p1[i].loss_pct, p1[i].you_ms, p1_dest_ping,
+					           estimated ? " ~est" : "");
+			}
+
+			/* 2-hop: so usa P1 como intermediario se voce->P1 < ping direto.
+			 * Se nao temos ping direto (direct_ping==-1), nao filtra -- tenta tudo. */
+			if (!p2) continue;
+			if (direct_ping > 0 && p1[i].you_ms >= direct_ping) continue;
+
+			for (j = 0; j < p1[i].ps.count; j++) {
+				ps_entry_t *nb = &p1[i].ps.entries[j];
+				int k, total2, p2_dest_ping;
+				qbool estimated2;
+				char proxylist[MAX_PROXYLIST];
+
+				if (ntohs(nb->addr.port) != 30000)           continue;
+				if (CL_BR_IsTarget(&nb->addr))               continue;
+				if (CL_BR_AdrEqual(&nb->addr, &p1[i].addr))  continue;
+
+				for (k = 0; k < p2_count; k++)
+					if (CL_BR_AdrEqual(&p2[k].addr, &nb->addr)) break;
+				if (k >= p2_count || !p2[k].replied) continue;
+
+				p2_dest_ping = (p2[k].ps.dest_ping >= 0)
+				               ? p2[k].ps.dest_ping : direct_ping;
+				if (p2_dest_ping < 0) continue;
+
+				estimated2 = (p2[k].ps.dest_ping < 0);
+				total2 = p1[i].you_ms + nb->dist_ms + p2_dest_ping;
+
+				snprintf(proxylist, sizeof(proxylist), "%s@%s",
+				         p1[i].ip_str, p2[k].ip_str);
+				snprintf(lbl, sizeof(lbl), "via %s -> %s [2 hops%s]",
+				         p1[i].name, p2[k].ip_str, estimated2 ? " ~est" : "");
+				CL_BR_AddRoute(proxylist, lbl, (float)total2, p2[k].loss_pct, true);
+
+				if (verbose >= 1)
+					Com_Printf("  [%s -> %s] %s%dms&r loss=%.0f%%  "
+					           "(you %dms + P1->P2 %dms + P2->dest %dms%s) &cf802 hops&r\n",
+					           p1[i].name, p2[k].ip_str,
+					           CL_BR_PingColor((float)total2), total2,
+					           p2[k].loss_pct,
+					           p1[i].you_ms, nb->dist_ms, p2_dest_ping,
+					           estimated2 ? " ~est" : "");
+			}
+		}
+	}
+
+	// ══════════════════════════════════════════════════════════════════
+	// Step 6: conexao direta
+	// ══════════════════════════════════════════════════════════════════
+step_direct:
+	{
+		int dp = CL_BR_GetBrowserPing(&br_target_addr);
+		if (dp > 0) {
+			if (verbose >= 1)
+				Com_Printf("  [direct] %s%dms&r\n", CL_BR_PingColor((float)dp), dp);
+			CL_BR_AddRoute("", "direct", (float)dp, 0.0f, false);
+		}
+	}
+
+	Q_free(p1);
+	Q_free(p2);
+	br_measuring = false;
+
+	if (br_route_count == 0) {
+		Com_Printf("connectbr: no routes found.\n");
+		return 0;
+	}
+
+	qsort(br_routes, br_route_count, sizeof(route_t), CL_BR_RouteCompare);
+
+	if (br_route_count > 10)
+		br_route_count = 10;
+
+	/* Monta ranking no buffer -- sera impresso pela thread principal em CL_ConnectBR_Frame */
+	{
+		int  show = (br_route_count < 6) ? br_route_count : 6;
+		char tmp[256];
+		br_ranking_buf[0] = '\0';
+		snprintf(tmp, sizeof(tmp), "\n&cf80connectbr: top %d routes&r\n", show);
+		strlcat(br_ranking_buf, tmp, sizeof(br_ranking_buf));
+		for (i = 0; i < show; i++) {
+			snprintf(tmp, sizeof(tmp), "  &cf80#%d&r  %s%.0fms&r  %s%.1f%%&r  %s\n",
+			         i + 1,
+			         CL_BR_PingColor(br_routes[i].ping_ms), br_routes[i].ping_ms,
+			         CL_BR_LossColor(br_routes[i].loss_pct), br_routes[i].loss_pct,
+			         br_routes[i].label);
+			strlcat(br_ranking_buf, tmp, sizeof(br_ranking_buf));
+		}
+	}
+
+	br_current_route = 0;
+	br_active        = true;
+	br_done          = true;   /* sinaliza thread principal para imprimir e conectar */
+	return 0;
+}
+
+// --------------------------------------------
+// PUBLIC: connectbr <address>
+// Valida argumentos, seta estado e dispara thread.
+// Retorna imediatamente -- sem freeze.
+// --------------------------------------------
+void CL_Connect_BestRoute_f(void)
+{
+	const char *addr;
+
+	if (br_measuring) {
+		Com_Printf("connectbr: measurement already in progress.\n");
+		return;
+	}
+
+	if (Cmd_Argc() != 2) {
+		Com_Printf("Usage: connectbr <address>\n");
+		Com_Printf("  Tests 1-hop and 2-hop proxy routes and connects via the best one.\n");
+		Com_Printf("  Use connectnext to try the next route.\n");
+		return;
+	}
+
+	addr = Cmd_Argv(1);
+	if (!addr || !*addr)                    { Com_Printf("connectbr: empty address\n");    return; }
+	if (strlen(addr) > MAX_ADDRESS_LENGTH)  { Com_Printf("connectbr: address too long\n"); return; }
+
+	if (!NET_StringToAdr(addr, &br_target_addr)) {
+		Com_Printf("connectbr: invalid address '%s'\n", addr);
+		return;
+	}
+	if (br_target_addr.port == 0)
+		br_target_addr.port = htons(27500);
+
+	if (SB_PingTree_IsBuilding()) {
+		Com_Printf("connectbr: ping tree still building -- retry later.\n");
+		return;
+	}
+
+	br_measuring     = true;
+	br_route_count   = 0;
+	br_current_route = 0;
+	br_active        = false;
+	br_done          = false;
+	br_ranking_buf[0] = '\0';
+	Cvar_Set(&cl_proxyaddr, "");
+
+	if ((int)cl_connectbr_verbose.value >= 1)
+		Com_Printf("\n&cf80connectbr:&r testing routes to %s\n", addr);
+
+	if (Sys_CreateDetachedThread(CL_BR_MeasureProc, NULL) < 0) {
+		Com_Printf("connectbr: failed to create measurement thread.\n");
+		br_measuring = false;
+	}
+}
+
+// --------------------------------------------
+// PUBLIC: connectnext
+// --------------------------------------------
+void CL_Connect_Next_f(void)
+{
+	if (!br_active || br_route_count == 0) {
+		Com_Printf("connectnext: no active connectbr session.\n");
+		Com_Printf("  Use 'connectbr <address>' first.\n");
+		return;
+	}
+
+	br_current_route++;
+
+	if (br_current_route >= br_route_count) {
+		Com_Printf("connectnext: no more routes (tried all %d).\n", br_route_count);
+		br_active = false;
+		return;
+	}
+
+	Host_EndGame();
+	CL_BR_ApplyRoute(br_current_route);
+}
+
+// --------------------------------------------
+// PUBLIC: CL_ConnectBR_Frame
+// Chamada pela thread principal a cada frame.
+// Verifica se a thread de medicao terminou e,
+// se sim, imprime o ranking e conecta -- tudo
+// na thread principal, sem race condition.
+// --------------------------------------------
+void CL_ConnectBR_Frame(void)
+{
+	if (!br_done) return;
+	br_done = false;
+
+	if (br_route_count == 0) return;
+
+	/* Imprime ranking aqui -- thread principal, Com_Printf seguro */
+	if (br_ranking_buf[0])
+		Com_Printf("%s", br_ranking_buf);
+
+	CL_BR_ApplyRoute(0);
+}
+
+// --------------------------------------------
+// PUBLIC: register cvars
+// --------------------------------------------
+void CL_ConnectBR_Init(void)
+{
+	Cvar_SetCurrentGroup(CVAR_GROUP_NETWORK);
+	Cvar_Register(&cl_connectbr_timeout_ms);
+	Cvar_Register(&cl_connectbr_ping_green);
+	Cvar_Register(&cl_connectbr_ping_yellow);
+	Cvar_Register(&cl_connectbr_ping_orange);
+	Cvar_Register(&cl_connectbr_weight_ping);
+	Cvar_Register(&cl_connectbr_weight_loss);
+	Cvar_Register(&cl_connectbr_test_packets);
+	Cvar_Register(&cl_connectbr_packet_delay);
+	Cvar_Register(&cl_connectbr_verbose);
+	Cvar_Register(&cl_connectbr_debug);
+	Cvar_ResetCurrentGroup();
+}

--- a/src/cl_connectbr.h
+++ b/src/cl_connectbr.h
@@ -16,5 +16,7 @@ void CL_ConnectBR_Init(void);          // register cvars — call from CL_InitLo
 void CL_ConnectBR_Frame(void);         // call every frame from main loop — call from CL_Frame
 void CL_Connect_BestRoute_f(void);     // connectbr command
 void CL_Connect_Next_f(void);          // connectnext command
+void CL_Connect_Previous_f(void);      // connectprevious command
+void CL_Connect_Info_f(void);          // connectinfo command
 
 #endif // __CL_CONNECTBR_H__

--- a/src/cl_connectbr.h
+++ b/src/cl_connectbr.h
@@ -1,0 +1,21 @@
+/*
+Copyright (C) 2024 unezQuake team
+cl_connectbr.h - Smart route selection for connectbr/connectnext commands
+*/
+#ifndef __CL_CONNECTBR_H__
+#define __CL_CONNECTBR_H__
+ 
+// quakedef.h must be included before this header (provides cvar_t etc.)
+// cl_main.c already includes quakedef.h before cl_connectbr.h so this is fine.
+// If included standalone, add: #include "quakedef.h"
+ 
+// CVars (defined in cl_connectbr.c — include quakedef.h before this header if needed)
+ 
+// Public functions
+void CL_ConnectBR_Init(void);          // register cvars — call from CL_InitLocal
+void CL_ConnectBR_Frame(void);         // call every frame from main loop — call from CL_Frame
+void CL_Connect_BestRoute_f(void);     // connectbr command
+void CL_Connect_Next_f(void);          // connectnext command
+ 
+#endif // __CL_CONNECTBR_H__
+ 

--- a/src/cl_connectbr.h
+++ b/src/cl_connectbr.h
@@ -4,18 +4,17 @@ cl_connectbr.h - Smart route selection for connectbr/connectnext commands
 */
 #ifndef __CL_CONNECTBR_H__
 #define __CL_CONNECTBR_H__
- 
+
 // quakedef.h must be included before this header (provides cvar_t etc.)
 // cl_main.c already includes quakedef.h before cl_connectbr.h so this is fine.
 // If included standalone, add: #include "quakedef.h"
- 
+
 // CVars (defined in cl_connectbr.c — include quakedef.h before this header if needed)
- 
+
 // Public functions
 void CL_ConnectBR_Init(void);          // register cvars — call from CL_InitLocal
 void CL_ConnectBR_Frame(void);         // call every frame from main loop — call from CL_Frame
 void CL_Connect_BestRoute_f(void);     // connectbr command
 void CL_Connect_Next_f(void);          // connectnext command
- 
+
 #endif // __CL_CONNECTBR_H__
- 

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -2150,6 +2150,8 @@ static void CL_InitLocal(void)
 	Cmd_AddCommand ("connect", CL_Connect_f);
 	Cmd_AddCommand ("connectbr", CL_Connect_BestRoute_f);
 	Cmd_AddCommand ("connectnext", CL_Connect_Next_f);
+	Cmd_AddCommand ("connectprevious", CL_Connect_Previous_f);
+	Cmd_AddCommand ("connectinfo", CL_Connect_Info_f);
 	CL_ConnectBR_Init();
 
 	Cmd_AddCommand ("qwurl", CL_QWURL_f);

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -1060,10 +1060,8 @@ void CL_Connect_f (void)
 }
 
 // CL_Connect_BestRoute_f / CL_Connect_Next_f moved to cl_connectbr.c: the
-// upstream one-shot ping-tree connect above is now Step 1 inside that
-// file's CL_BR_MeasureProc (still used as the first/fastest candidate
-// when available), extended with batched 1-2 hop pingstatus probing.
-// See cl_connectbr.c's header comment for the full design.
+// connectbr now presents the alternatives already measured by sb_findroutes;
+// connectnext cycles that cached ranking without starting another scan.
 
 void CL_TCPConnect_f (void)
 {

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "cdaudio.h"
 #include "cl_slist.h"
+#include "cl_connectbr.h"
 #include "movie.h"
 #include "logging.h"
 #include "demo_extension.h"
@@ -1058,27 +1059,11 @@ void CL_Connect_f (void)
 	if (server_buf) Q_free(server_buf);
 }
 
-void CL_Connect_BestRoute_f(void)
-{
-	if (Cmd_Argc() != 2) {
-		Com_Printf("Usage: %s <address>\nConnects to given server via fastest available path (ping-wise).\n", Cmd_Argv(0));
-		Com_Printf("Requires Server Browser refreshed with sb_findroutes 1\n");
-		return;
-	}
-	else {
-		netadr_t adr;
-		if (!NET_StringToAdr(Cmd_Argv(1), &adr)) {
-			Com_Printf("Invalid address\n");
-			return;
-		}
-
-		if (adr.port == 0)
-			adr.port = htons(27500);
-
-		SB_PingTree_DumpPath(&adr);
-		SB_PingTree_ConnectBestPath(&adr);
-	}
-}
+// CL_Connect_BestRoute_f / CL_Connect_Next_f moved to cl_connectbr.c: the
+// upstream one-shot ping-tree connect above is now Step 1 inside that
+// file's CL_BR_MeasureProc (still used as the first/fastest candidate
+// when available), extended with batched 1-2 hop pingstatus probing.
+// See cl_connectbr.c's header comment for the full design.
 
 void CL_TCPConnect_f (void)
 {
@@ -2166,6 +2151,8 @@ static void CL_InitLocal(void)
 	Cmd_AddCommand ("disconnect", CL_Disconnect_f);
 	Cmd_AddCommand ("connect", CL_Connect_f);
 	Cmd_AddCommand ("connectbr", CL_Connect_BestRoute_f);
+	Cmd_AddCommand ("connectnext", CL_Connect_Next_f);
+	CL_ConnectBR_Init();
 
 	Cmd_AddCommand ("qwurl", CL_QWURL_f);
 
@@ -2941,6 +2928,8 @@ void CL_Frame(double time)
 #endif
 
 	SB_ExecuteQueuedTriggers();
+
+	CL_ConnectBR_Frame();
 
 	R_ParticleEndFrame();
 


### PR DESCRIPTION
## Proposal

Port the qwfwd mesh route selection into the primary ezQuake source tree as a client-side enhancement to `sb_findroutes`.

## File-by-file scope

- `CMakeLists.txt`: includes the browser route implementation.
- `src/EX_browser.h`: exposes route-selection integration points.
- `src/EX_browser_pathfind.c`: queries measured mesh routes, ranks complete paths, enforces hop bounds, and falls back to existing direct/legacy behavior.
- `src/cl_connectbr.h`: declares the route connection interface.
- `src/cl_connectbr.c`: implements `connectbr`/`connectnext`, keeps proxy hops in `cl_proxyaddr`, and targets the real game server with `connect`.
- `src/cl_main.c`: registers the commands and connects route state to the client lifecycle.

## Validation

The same implementation was built in the UnezQuake Windows MSBuild Release configuration and exercised with the four available qwfwd mesh test instances. Multi-hop route discovery, ranking, generated `cl_proxyaddr`, direct-server `connect`, cached alternatives, and legacy fallback were verified there. A native ezQuake-source build should be run by CI/review because this repository has a different build baseline.

## Dependency

Complete mesh measurements require qwfwd instances with the mesh protocol proposed separately in QW-Group/qwfwd#29. Without updated peers, existing direct/legacy behavior remains available.


## Follow-up hardening

Review follow-up adds bounded route arithmetic, rejects overlong proxy chains instead of using truncated cl_proxyaddr values, limits selected paths by hop count, expires route measurements after 120 seconds, recovers cleanly if the ping-tree worker cannot start, removes an unused cvar, uses neutral source attribution, and cleans stale comments/whitespace.

The updated branch builds successfully as a Linux x86_64 Release.
